### PR TITLE
feat: provisioning flow to figure out message payload encoding

### DIFF
--- a/modules/redis-client/src/main/scala/io/renku/queue/client/Message.scala
+++ b/modules/redis-client/src/main/scala/io/renku/queue/client/Message.scala
@@ -20,6 +20,21 @@ package io.renku.queue.client
 
 import scodec.bits.ByteVector
 
-final case class Message(id: MessageId, payload: ByteVector)
+final case class Message(id: MessageId, encoding: Encoding, payload: ByteVector)
 
 final case class MessageId(value: String) extends AnyVal
+
+sealed trait Encoding extends Product:
+  lazy val name: String = productPrefix
+
+object Encoding:
+
+  val all: Set[Encoding] = Set(Binary, Json)
+
+  def from(v: String): Either[IllegalArgumentException, Encoding] =
+    all
+      .find(_.productPrefix.equalsIgnoreCase(v))
+      .toRight(new IllegalArgumentException(s"'$v' not a valid payload Encoding"))
+
+  case object Binary extends Encoding
+  case object Json extends Encoding

--- a/modules/redis-client/src/main/scala/io/renku/queue/client/QueueClient.scala
+++ b/modules/redis-client/src/main/scala/io/renku/queue/client/QueueClient.scala
@@ -25,7 +25,7 @@ import scodec.bits.ByteVector
 
 trait QueueClient[F[_]] {
 
-  def enqueue(queueName: QueueName, message: ByteVector): F[MessageId]
+  def enqueue(queueName: QueueName, message: ByteVector, encoding: Encoding): F[MessageId]
 
   def acquireEventsStream(
       queueName: QueueName,

--- a/modules/redis-client/src/test/scala/io/renku/redis/client/RedisClientGenerators.scala
+++ b/modules/redis-client/src/test/scala/io/renku/redis/client/RedisClientGenerators.scala
@@ -29,6 +29,9 @@ object RedisClientGenerators:
       .chooseNum(3, 10)
       .flatMap(Gen.stringOfN(_, alphaLowerChar).map(QueueName(_)))
 
+  val encodingGen: Gen[Encoding] =
+    Gen.oneOf(Encoding.all)
+
   val clientIdGen: Gen[ClientId] =
     Gen
       .chooseNum(3, 10)

--- a/modules/search-api/src/test/scala/io/renku/search/api/SearchApiSpec.scala
+++ b/modules/search-api/src/test/scala/io/renku/search/api/SearchApiSpec.scala
@@ -19,7 +19,6 @@
 package io.renku.search.api
 
 import cats.effect.IO
-import cats.syntax.all.*
 import io.renku.api.Project as ApiProject
 import io.renku.avro.codec.AvroDecoder
 import io.renku.avro.codec.all.given
@@ -41,7 +40,7 @@ class SearchApiSpec extends CatsEffectSuite with SearchSolrSpec:
       val project2 = projectDocumentGen("disparate", "disparate description").generateOne
       val searchApi = new SearchApiImpl[IO](client)
       for {
-        _ <- (project1 :: project2 :: Nil).traverse_(client.insertProject)
+        _ <- client.insertProjects(project1 :: project2 :: Nil)
         response <- searchApi.find("matching")
         results <- response.as[List[ApiProject]]
       } yield assert(results contains toApiProject(project1))

--- a/modules/search-solr-client/src/main/scala/io/renku/search/solr/client/SearchSolrClient.scala
+++ b/modules/search-solr-client/src/main/scala/io/renku/search/solr/client/SearchSolrClient.scala
@@ -25,7 +25,7 @@ import io.renku.solr.client.{SolrClient, SolrConfig}
 
 trait SearchSolrClient[F[_]]:
 
-  def insertProject(project: Project): F[Unit]
+  def insertProjects(projects: Seq[Project]): F[Unit]
 
   def findProjects(phrase: String): F[List[Project]]
 

--- a/modules/search-solr-client/src/main/scala/io/renku/search/solr/client/SearchSolrClientImpl.scala
+++ b/modules/search-solr-client/src/main/scala/io/renku/search/solr/client/SearchSolrClientImpl.scala
@@ -27,8 +27,8 @@ import io.renku.solr.client.{QueryString, SolrClient}
 private class SearchSolrClientImpl[F[_]: Async](solrClient: SolrClient[F])
     extends SearchSolrClient[F]:
 
-  override def insertProject(project: Project): F[Unit] =
-    solrClient.insert(Seq(project)).void
+  override def insertProjects(projects: Seq[Project]): F[Unit] =
+    solrClient.insert(projects).void
 
   override def findProjects(phrase: String): F[List[Project]] =
     solrClient

--- a/modules/search-solr-client/src/test/scala/io/renku/search/solr/client/SearchSolrClientSpec.scala
+++ b/modules/search-solr-client/src/test/scala/io/renku/search/solr/client/SearchSolrClientSpec.scala
@@ -29,7 +29,7 @@ class SearchSolrClientSpec extends CatsEffectSuite with SearchSolrSpec:
       val project =
         projectDocumentGen("solr-project", "solr project description").generateOne
       for {
-        _ <- client.insertProject(project)
+        _ <- client.insertProjects(Seq(project))
         r <- client.findProjects("solr")
         _ = assert(r contains project)
       } yield ()


### PR DESCRIPTION
This change makes the Provisioning flow try some simplistic approach to determine if the message's payload is binary or JSON encoded and use the appropriate decoding strategy.