### PR TITLE
Fix condition when stopping test servers

### DIFF
--- a/project/RedisServer.scala
+++ b/project/RedisServer.scala
@@ -82,7 +82,8 @@ class RedisServer(module: String, port: Int) {
   }
 
   def stop(): Unit =
-    if (!skipServer && wasStartedHere.get()) {
+    if (skipServer || !wasStartedHere.get()) ()
+    else {
       println(s"Stopping Redis container for '$module'")
       stopCmd.!!
       ()

--- a/project/SolrServer.scala
+++ b/project/SolrServer.scala
@@ -100,7 +100,7 @@ class SolrServer(module: String, port: Int) {
   }
 
   def stop(): Unit =
-    if (!skipServer && !wasStartedHere.get()) ()
+    if (skipServer || !wasStartedHere.get()) ()
     else {
       println(s"Stopping Solr container for '$module'")
       stopCmd.!!


### PR DESCRIPTION
It was broken for solr; the same condition is used for Redis as well, for consistency.