### PR TITLE
refactor: provisioning routes refactor

### DIFF
--- a/modules/config-values/src/main/scala/io/renku/search/config/ConfigValues.scala
+++ b/modules/config-values/src/main/scala/io/renku/search/config/ConfigValues.scala
@@ -47,8 +47,8 @@ object ConfigValues extends ConfigDecoders:
     (host, port, sentinel, maybeDB, maybePass, maybeMasterSet).mapN(RedisConfig.apply)
   }
 
-  val eventsQueueName: ConfigValue[Effect, QueueName] =
-    renv("REDIS_QUEUE_NAME").default("events").as[QueueName]
+  def eventQueue(eventType: String): ConfigValue[Effect, QueueName] =
+    renv(s"REDIS_QUEUE_$eventType").default("events").as[QueueName]
 
   val retryOnErrorDelay: ConfigValue[Effect, FiniteDuration] =
     renv("RETRY_ON_ERROR_DELAY").default("2 seconds").as[FiniteDuration]

--- a/modules/redis-client/src/test/scala/io/renku/redis/client/util/RedisSpec.scala
+++ b/modules/redis-client/src/test/scala/io/renku/redis/client/util/RedisSpec.scala
@@ -39,6 +39,7 @@ trait RedisSpec:
   abstract class RedisFixture extends Fixture[Resource[IO, RedisClient]]("redis"):
     def asRedisCommands(): Resource[IO, RedisCommands[IO, String, String]]
     def asRedisQueueClient(): Resource[IO, RedisQueueClient[IO]]
+    def redisConfig: RedisConfig
 
   val withRedisClient: RedisFixture = new RedisFixture:
 
@@ -54,11 +55,12 @@ trait RedisSpec:
       apply().flatMap(createRedisCommands)
 
     override def asRedisQueueClient(): Resource[IO, RedisQueueClient[IO]] =
-      RedisQueueClient.make[IO](
-        RedisConfig(
-          RedisHost(server.host),
-          RedisPort(server.port)
-        )
+      RedisQueueClient.make[IO](redisConfig)
+
+    override lazy val redisConfig: RedisConfig =
+      RedisConfig(
+        RedisHost(server.host),
+        RedisPort(server.port)
       )
 
     override def beforeAll(): Unit =

--- a/modules/search-api/src/test/scala/io/renku/search/api/SearchApiSpec.scala
+++ b/modules/search-api/src/test/scala/io/renku/search/api/SearchApiSpec.scala
@@ -26,6 +26,7 @@ import io.renku.search.query.Query
 import io.renku.search.solr.client.SearchSolrClientGenerators.*
 import io.renku.search.solr.client.SearchSolrSpec
 import io.renku.search.solr.documents.Project as SolrProject
+import io.renku.search.solr.documents.Project.given
 import munit.CatsEffectSuite
 import scribe.Scribe
 
@@ -39,7 +40,7 @@ class SearchApiSpec extends CatsEffectSuite with SearchSolrSpec:
       val project2 = projectDocumentGen("disparate", "disparate description").generateOne
       val searchApi = new SearchApiImpl[IO](client)
       for {
-        _ <- client.insertProjects(project1 :: project2 :: Nil)
+        _ <- client.insert(project1 :: project2 :: Nil)
         results <- searchApi
           .query(mkQuery("matching"))
           .map(_.fold(err => fail(s"Calling Search API failed with $err"), identity))

--- a/modules/search-provision/src/main/scala/io/renku/search/provision/Microservice.scala
+++ b/modules/search-provision/src/main/scala/io/renku/search/provision/Microservice.scala
@@ -41,7 +41,7 @@ object Microservice extends IOApp:
 
   private def startProvisioning(cfg: SearchProvisionConfig): IO[Unit] =
     ProjectCreatedProvisioning
-      .make[IO](cfg.queues, cfg.redisConfig, cfg.solrConfig)
+      .make[IO](cfg.queuesConfig.projectCreated, cfg.redisConfig, cfg.solrConfig)
       .evalMap(_.provisioningProcess.start)
       .use(_ => IO.never)
       .handleErrorWith { err =>

--- a/modules/search-provision/src/main/scala/io/renku/search/provision/Microservice.scala
+++ b/modules/search-provision/src/main/scala/io/renku/search/provision/Microservice.scala
@@ -19,9 +19,10 @@
 package io.renku.search.provision
 
 import cats.effect.{ExitCode, IO, IOApp, Temporal}
+import io.renku.logging.LoggingSetup
+import io.renku.search.provision.project.ProjectCreatedProvisioning
 import io.renku.search.solr.schema.Migrations
 import io.renku.solr.client.migration.SchemaMigrator
-import io.renku.logging.LoggingSetup
 import scribe.Scribe
 import scribe.cats.*
 
@@ -39,9 +40,9 @@ object Microservice extends IOApp:
     } yield ExitCode.Success
 
   private def startProvisioning(cfg: SearchProvisionConfig): IO[Unit] =
-    SearchProvisioner
-      .make[IO](cfg.queueName, cfg.redisConfig, cfg.solrConfig)
-      .evalMap(_.provisionSolr.start)
+    ProjectCreatedProvisioning
+      .make[IO](cfg.queues, cfg.redisConfig, cfg.solrConfig)
+      .evalMap(_.provisioningProcess.start)
       .use(_ => IO.never)
       .handleErrorWith { err =>
         Scribe[IO].error("Starting provisioning failure, retrying", err) >>

--- a/modules/search-provision/src/main/scala/io/renku/search/provision/QueuesConfig.scala
+++ b/modules/search-provision/src/main/scala/io/renku/search/provision/QueuesConfig.scala
@@ -18,29 +18,16 @@
 
 package io.renku.search.provision
 
-import cats.syntax.all.*
 import ciris.{ConfigValue, Effect}
-import io.renku.redis.client.RedisConfig
+import io.renku.redis.client.QueueName
 import io.renku.search.config.ConfigValues
-import io.renku.solr.client.SolrConfig
 
-import scala.concurrent.duration.FiniteDuration
-
-final case class SearchProvisionConfig(
-    redisConfig: RedisConfig,
-    solrConfig: SolrConfig,
-    retryOnErrorDelay: FiniteDuration,
-    verbosity: Int,
-    queuesConfig: QueuesConfig
+final case class QueuesConfig(
+    projectCreated: QueueName
 )
 
-object SearchProvisionConfig:
-
-  val config: ConfigValue[Effect, SearchProvisionConfig] =
-    (
-      ConfigValues.redisConfig,
-      ConfigValues.solrConfig,
-      ConfigValues.retryOnErrorDelay,
-      ConfigValues.logLevel,
-      QueuesConfig.config
-    ).mapN(SearchProvisionConfig.apply)
+object QueuesConfig:
+  val config: ConfigValue[Effect, QueuesConfig] =
+    ConfigValues
+      .eventQueue("projectCreated")
+      .map(QueuesConfig.apply)

--- a/modules/search-provision/src/main/scala/io/renku/search/provision/SearchProvisionConfig.scala
+++ b/modules/search-provision/src/main/scala/io/renku/search/provision/SearchProvisionConfig.scala
@@ -28,7 +28,7 @@ import scala.concurrent.duration.FiniteDuration
 
 final case class SearchProvisionConfig(
     redisConfig: RedisConfig,
-    queueName: QueueName,
+    queues: QueueName,
     solrConfig: SolrConfig,
     retryOnErrorDelay: FiniteDuration,
     verbosity: Int

--- a/modules/search-provision/src/main/scala/io/renku/search/provision/project/ProjectCreatedProvisioning.scala
+++ b/modules/search-provision/src/main/scala/io/renku/search/provision/project/ProjectCreatedProvisioning.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.search.provision.project
+
+import cats.Show
+import cats.effect.{Async, Resource}
+import cats.syntax.all.*
+import fs2.io.net.Network
+import io.github.arainko.ducktape.*
+import io.renku.avro.codec.decoders.all.given
+import io.renku.events.v1
+import io.renku.events.v1.{ProjectCreated, Visibility}
+import io.renku.redis.client.{ClientId, QueueName, RedisConfig}
+import io.renku.search.model.*
+import io.renku.search.provision.SolrProvisioningProcess
+import io.renku.search.provision.TypeTransformers.given
+import io.renku.search.solr.documents
+import io.renku.solr.client.SolrConfig
+import scribe.Scribe
+
+trait ProjectCreatedProvisioning[F[_]] extends SolrProvisioningProcess[F]
+
+object ProjectCreatedProvisioning:
+
+  private val clientId: ClientId = ClientId("search-provisioner")
+
+  def make[F[_]: Async: Network](
+      queueName: QueueName,
+      redisConfig: RedisConfig,
+      solrConfig: SolrConfig
+  ): Resource[F, SolrProvisioningProcess[F]] =
+    given Scribe[F] = scribe.cats[F]
+    SolrProvisioningProcess.make[F, ProjectCreated, documents.Project](
+      queueName,
+      ProjectCreated.SCHEMA$,
+      redisConfig,
+      solrConfig
+    )
+
+  private given Show[ProjectCreated] =
+    Show.show[ProjectCreated](pc => show"slug '${pc.slug}'")
+
+  private given Transformer[ProjectCreated, documents.Project] =
+    _.into[documents.Project].transform(Field.default(_.score))

--- a/modules/search-provision/src/main/scala/io/renku/search/provision/project/ProjectCreatedProvisioning.scala
+++ b/modules/search-provision/src/main/scala/io/renku/search/provision/project/ProjectCreatedProvisioning.scala
@@ -26,7 +26,7 @@ import io.github.arainko.ducktape.*
 import io.renku.avro.codec.decoders.all.given
 import io.renku.events.v1
 import io.renku.events.v1.{ProjectCreated, Visibility}
-import io.renku.redis.client.{ClientId, QueueName, RedisConfig}
+import io.renku.redis.client.{QueueName, RedisConfig}
 import io.renku.search.model.*
 import io.renku.search.provision.SolrProvisioningProcess
 import io.renku.search.provision.TypeTransformers.given
@@ -37,8 +37,6 @@ import scribe.Scribe
 trait ProjectCreatedProvisioning[F[_]] extends SolrProvisioningProcess[F]
 
 object ProjectCreatedProvisioning:
-
-  private val clientId: ClientId = ClientId("search-provisioner")
 
   def make[F[_]: Async: Network](
       queueName: QueueName,

--- a/modules/search-solr-client/src/main/scala/io/renku/search/solr/client/SearchSolrClientImpl.scala
+++ b/modules/search-solr-client/src/main/scala/io/renku/search/solr/client/SearchSolrClientImpl.scala
@@ -20,6 +20,7 @@ package io.renku.search.solr.client
 
 import cats.effect.Async
 import cats.syntax.all.*
+import io.bullet.borer.Encoder
 import io.renku.search.solr.documents.Project
 import io.renku.search.solr.query.LuceneQueryInterpreter
 import io.renku.search.solr.schema.EntityDocumentSchema
@@ -33,8 +34,8 @@ private class SearchSolrClientImpl[F[_]: Async](solrClient: SolrClient[F])
   private[this] val logger = scribe.cats.effect[F]
   private[this] val interpreter = LuceneQueryInterpreter.forSync[F]
 
-  override def insertProjects(projects: Seq[Project]): F[Unit] =
-    solrClient.insert(projects).void
+  override def insert[D: Encoder](documents: Seq[D]): F[Unit] =
+    solrClient.insert(documents).void
 
   override def queryProjects(
       query: Query,

--- a/modules/search-solr-client/src/test/scala/io/renku/search/solr/client/SearchSolrClientSpec.scala
+++ b/modules/search-solr-client/src/test/scala/io/renku/search/solr/client/SearchSolrClientSpec.scala
@@ -19,9 +19,9 @@
 package io.renku.search.solr.client
 
 import cats.effect.IO
+import io.renku.search.query.Query
 import io.renku.search.solr.client.SearchSolrClientGenerators.*
 import munit.CatsEffectSuite
-import io.renku.search.query.Query
 
 class SearchSolrClientSpec extends CatsEffectSuite with SearchSolrSpec:
 
@@ -30,7 +30,7 @@ class SearchSolrClientSpec extends CatsEffectSuite with SearchSolrSpec:
       val project =
         projectDocumentGen("solr-project", "solr project description").generateOne
       for {
-        _ <- client.insertProjects(Seq(project))
+        _ <- client.insert(Seq(project))
         r <- client.queryProjects(Query.parse("solr").toOption.get, 10, 0)
         _ = assert(r.responseBody.docs.map(_.copy(score = None)) contains project)
       } yield ()

--- a/modules/search-solr-client/src/test/scala/io/renku/search/solr/client/SearchSolrSpec.scala
+++ b/modules/search-solr-client/src/test/scala/io/renku/search/solr/client/SearchSolrSpec.scala
@@ -20,26 +20,32 @@ package io.renku.search.solr.client
 
 import cats.effect.{IO, Resource}
 import io.renku.search.solr.schema.Migrations
-import io.renku.solr.client.SolrClient
 import io.renku.solr.client.migration.SchemaMigrator
 import io.renku.solr.client.util.SolrSpec
+import io.renku.solr.client.{SolrClient, SolrConfig}
 
 trait SearchSolrSpec extends SolrSpec:
   self: munit.Suite =>
 
-  val withSearchSolrClient: Fixture[Resource[IO, SearchSolrClient[IO]]] =
-    new Fixture[Resource[IO, SearchSolrClient[IO]]]("search-solr"):
+  abstract class SolrFixture
+      extends Fixture[Resource[IO, SearchSolrClient[IO]]]("search-solr"):
+    def solrConfig: SolrConfig
 
-      def apply(): Resource[IO, SearchSolrClient[IO]] =
-        SolrClient[IO](solrConfig.copy(core = server.searchCoreName))
-          .evalTap(SchemaMigrator[IO](_).migrate(Migrations.all).attempt.void)
-          .map(new SearchSolrClientImpl[IO](_))
+  val withSearchSolrClient: SolrFixture = new SolrFixture:
 
-      override def beforeAll(): Unit =
-        server.start()
+    def apply(): Resource[IO, SearchSolrClient[IO]] =
+      SolrClient[IO](solrConfig)
+        .evalTap(SchemaMigrator[IO](_).migrate(Migrations.all).attempt.void)
+        .map(new SearchSolrClientImpl[IO](_))
 
-      override def afterAll(): Unit =
-        server.stop()
+    override lazy val solrConfig: SolrConfig =
+      self.solrConfig.copy(core = server.searchCoreName)
+
+    override def beforeAll(): Unit =
+      server.start()
+
+    override def afterAll(): Unit =
+      server.stop()
 
   override def munitFixtures: Seq[Fixture[_]] =
     List(withSearchSolrClient)


### PR DESCRIPTION
This PR abstracts the provisioning route logic into a common place called `SolrProvisioningProcess`. The Process is configurable so it can deal with different event types.