### PR TITLE
fix: Create correct solr query in case only `sort` terms are specfified

### DIFF
--- a/modules/commons/src/main/scala/io/renku/logging/LoggingSetup.scala
+++ b/modules/commons/src/main/scala/io/renku/logging/LoggingSetup.scala
@@ -28,7 +28,11 @@ object LoggingSetup:
     println(s">> Setting up logging with verbosity=$verbosity")
     val root = scribe.Logger.root.clearHandlers().clearModifiers()
     verbosity match
-      case n if n <= 0 =>
+      case n if n < 0 =>
+        ()
+
+      case 0 =>
+        root.withMinimumLevel(Level.Error).replace()
         ()
 
       case 1 =>

--- a/modules/commons/src/test/scala/io/renku/search/GeneratorSyntax.scala
+++ b/modules/commons/src/test/scala/io/renku/search/GeneratorSyntax.scala
@@ -32,6 +32,8 @@ trait GeneratorSyntax:
         case Some(a) => a
         case None    => generateOne
 
+    def generateSome: Option[A] = Some(generateOne)
+
     def stream: Stream[Gen, A] =
       Stream.repeatEval(self)
 

--- a/modules/commons/src/test/scala/io/renku/search/GeneratorSyntax.scala
+++ b/modules/commons/src/test/scala/io/renku/search/GeneratorSyntax.scala
@@ -16,28 +16,27 @@
  * limitations under the License.
  */
 
-package io.renku.search.solr.query
+package io.renku.search
 
-import cats.Monoid
-import cats.syntax.all.*
-import io.renku.search.query.Order
-import io.renku.solr.client.SolrSort
+import fs2.Stream
+import cats.effect.IO
+import org.scalacheck.Gen
+import cats.arrow.FunctionK
 
-final case class SolrQuery(
-    query: SolrToken,
-    sort: SolrSort
-):
-  def withQuery(q: SolrToken): SolrQuery = copy(query = q)
-  def ++(next: SolrQuery): SolrQuery =
-    SolrQuery(query && next.query, sort ++ next.sort)
+trait GeneratorSyntax:
 
-object SolrQuery:
-  val empty: SolrQuery = SolrQuery(SolrToken.empty, SolrSort.empty)
+  extension [A](self: Gen[A])
+    @annotation.tailrec
+    final def generateOne: A =
+      self.sample match
+        case Some(a) => a
+        case None    => generateOne
 
-  def apply(e: SolrToken): SolrQuery =
-    SolrQuery(e, SolrSort.empty)
+    def stream: Stream[Gen, A] =
+      Stream.repeatEval(self)
 
-  def sort(order: Order): SolrQuery =
-    SolrQuery(SolrToken.empty, SolrSortCreate(order.fields))
+  extension [A](self: Stream[Gen, A])
+    def toIO: Stream[IO, A] =
+      self.translate(FunctionK.lift[Gen, IO]([X] => (gx: Gen[X]) => IO(gx.generateOne)))
 
-  given Monoid[SolrQuery] = Monoid.instance(empty, (a, b) => a ++ b)
+object GeneratorSyntax extends GeneratorSyntax

--- a/modules/redis-client/src/test/scala/io/renku/redis/client/RedisClientGenerators.scala
+++ b/modules/redis-client/src/test/scala/io/renku/redis/client/RedisClientGenerators.scala
@@ -41,5 +41,3 @@ object RedisClientGenerators:
       part1 <- Gen.chooseNum(3, 10)
       part2 <- Gen.chooseNum(3, 10)
     yield MessageId(s"$part1.$part2")
-
-  extension [V](gen: Gen[V]) def generateOne: V = gen.sample.getOrElse(generateOne)

--- a/modules/redis-client/src/test/scala/io/renku/redis/client/RedisQueueClientSpec.scala
+++ b/modules/redis-client/src/test/scala/io/renku/redis/client/RedisQueueClientSpec.scala
@@ -25,6 +25,7 @@ import dev.profunktor.redis4cats.streams.data.XAddMessage
 import dev.profunktor.redis4cats.streams.{RedisStream, Streaming}
 import fs2.*
 import fs2.concurrent.SignallingRef
+import io.renku.search.GeneratorSyntax.*
 import io.renku.redis.client.RedisClientGenerators.*
 import io.renku.redis.client.util.RedisSpec
 import munit.CatsEffectSuite

--- a/modules/renku-redis-client/src/test/scala/io/renku/queue/client/QueueClientSpec.scala
+++ b/modules/renku-redis-client/src/test/scala/io/renku/queue/client/QueueClientSpec.scala
@@ -28,6 +28,7 @@ import io.renku.queue.client.DataContentType.{Binary, Json}
 import io.renku.queue.client.Generators.*
 import io.renku.redis.client.{MessageId, RedisClientGenerators}
 import io.renku.redis.client.RedisClientGenerators.*
+import io.renku.search.GeneratorSyntax.*
 import munit.CatsEffectSuite
 
 class QueueClientSpec extends CatsEffectSuite with QueueSpec:

--- a/modules/search-api/src/test/scala/io/renku/search/api/SearchApiSpec.scala
+++ b/modules/search-api/src/test/scala/io/renku/search/api/SearchApiSpec.scala
@@ -21,6 +21,7 @@ package io.renku.search.api
 import cats.effect.IO
 import cats.syntax.all.*
 import io.github.arainko.ducktape.*
+import io.renku.search.GeneratorSyntax.*
 import io.renku.search.api.data.*
 import io.renku.search.model.users
 import io.renku.search.query.Query

--- a/modules/search-provision/src/test/scala/io/renku/search/provision/project/ProjectCreatedProvisionerSpec.scala
+++ b/modules/search-provision/src/test/scala/io/renku/search/provision/project/ProjectCreatedProvisionerSpec.scala
@@ -31,6 +31,7 @@ import io.renku.queue.client.Generators.messageHeaderGen
 import io.renku.queue.client.{DataContentType, QueueSpec}
 import io.renku.redis.client.RedisClientGenerators.*
 import io.renku.redis.client.{QueueName, RedisClientGenerators}
+import io.renku.search.GeneratorSyntax.*
 import io.renku.search.model.{EntityType, projects, users}
 import io.renku.search.query.Query
 import io.renku.search.query.Query.Segment

--- a/modules/search-provision/src/test/scala/io/renku/search/provision/user/UserAddedProvisionerSpec.scala
+++ b/modules/search-provision/src/test/scala/io/renku/search/provision/user/UserAddedProvisionerSpec.scala
@@ -31,6 +31,7 @@ import io.renku.queue.client.Generators.messageHeaderGen
 import io.renku.queue.client.{DataContentType, QueueSpec}
 import io.renku.redis.client.RedisClientGenerators.*
 import io.renku.redis.client.{QueueName, RedisClientGenerators}
+import io.renku.search.GeneratorSyntax.*
 import io.renku.search.model.{EntityType, users}
 import io.renku.search.query.Query
 import io.renku.search.query.Query.Segment

--- a/modules/search-query/src/main/scala/io/renku/search/query/SortableField.scala
+++ b/modules/search-query/src/main/scala/io/renku/search/query/SortableField.scala
@@ -19,6 +19,7 @@
 package io.renku.search.query
 
 import io.bullet.borer.{Decoder, Encoder}
+import cats.kernel.Order
 
 enum SortableField:
   case Name
@@ -30,6 +31,7 @@ enum SortableField:
 object SortableField:
   given Encoder[SortableField] = Encoder.forString.contramap(_.name)
   given Decoder[SortableField] = Decoder.forString.mapEither(fromString)
+  given Order[SortableField] = Order.by(_.name)
 
   private[this] val allNames: String = SortableField.values.map(_.name).mkString(", ")
 

--- a/modules/search-query/src/test/scala/io/renku/search/query/QueryGenerators.scala
+++ b/modules/search-query/src/test/scala/io/renku/search/query/QueryGenerators.scala
@@ -19,6 +19,7 @@
 package io.renku.search.query
 
 import cats.data.NonEmptyList
+import cats.Order as CatsOrder
 import cats.syntax.all.*
 import io.renku.search.model.{CommonGenerators, ModelGenerators}
 import io.renku.search.model.projects.Visibility
@@ -160,6 +161,7 @@ object QueryGenerators:
 
   val sortTerm: Gen[Order] =
     Gen.choose(1, 5).flatMap { len =>
+      given CatsOrder[Order.OrderedBy] = CatsOrder.by(_.field)
       CommonGenerators.nelOfN(len, orderedBy).map(_.distinct).map(Order.apply)
     }
 

--- a/modules/search-solr-client/src/main/scala/io/renku/search/solr/query/LuceneQueryEncoders.scala
+++ b/modules/search-solr-client/src/main/scala/io/renku/search/solr/query/LuceneQueryEncoders.scala
@@ -148,4 +148,7 @@ trait LuceneQueryEncoders:
   given query[F[_]: Monad](using
       se: SolrTokenEncoder[F, List[Segment]]
   ): SolrTokenEncoder[F, Query] =
-    se.contramap(_.segments)
+    se.contramap[Query](_.segments).modify(q =>
+      if (q.query.isEmpty) q.copy(query = SolrToken.allTypes)
+      else q
+    )

--- a/modules/search-solr-client/src/main/scala/io/renku/search/solr/query/LuceneQueryEncoders.scala
+++ b/modules/search-solr-client/src/main/scala/io/renku/search/solr/query/LuceneQueryEncoders.scala
@@ -148,7 +148,8 @@ trait LuceneQueryEncoders:
   given query[F[_]: Monad](using
       se: SolrTokenEncoder[F, List[Segment]]
   ): SolrTokenEncoder[F, Query] =
-    se.contramap[Query](_.segments).modify(q =>
-      if (q.query.isEmpty) q.copy(query = SolrToken.allTypes)
-      else q
-    )
+    se.contramap[Query](_.segments)
+      .modify(q =>
+        if (q.query.isEmpty) q.withQuery(SolrToken.allTypes)
+        else q
+      )

--- a/modules/search-solr-client/src/main/scala/io/renku/search/solr/query/SolrTokenEncoder.scala
+++ b/modules/search-solr-client/src/main/scala/io/renku/search/solr/query/SolrTokenEncoder.scala
@@ -22,11 +22,14 @@ import cats.{Applicative, Monad}
 import cats.syntax.all.*
 import scala.deriving.*
 import scala.collection.AbstractIterable
+import cats.Functor
 
 trait SolrTokenEncoder[F[_], A]:
   def encode(ctx: Context[F], value: A): F[SolrQuery]
   final def contramap[B](f: B => A): SolrTokenEncoder[F, B] =
     SolrTokenEncoder.create((ctx, b) => encode(ctx, f(b)))
+  final def modify(f: SolrQuery => SolrQuery)(using Functor[F]): SolrTokenEncoder[F, A] =
+    SolrTokenEncoder.create((ctx, a) => encode(ctx, a).map(f))
 
 object SolrTokenEncoder:
   def apply[F[_], A](using e: SolrTokenEncoder[F, A]): SolrTokenEncoder[F, A] = e

--- a/modules/search-solr-client/src/test/scala/io/renku/search/solr/client/SearchSolrClientGenerators.scala
+++ b/modules/search-solr-client/src/test/scala/io/renku/search/solr/client/SearchSolrClientGenerators.scala
@@ -22,6 +22,7 @@ import cats.syntax.all.*
 import io.renku.search.model.*
 import io.renku.search.model.ModelGenerators.*
 import io.renku.search.solr.documents.*
+import io.renku.search.GeneratorSyntax.*
 import org.scalacheck.Gen
 import org.scalacheck.cats.implicits.*
 
@@ -48,11 +49,6 @@ object SearchSolrClientGenerators:
   def userDocumentGen: Gen[User] =
     (userIdGen, Gen.option(userFirstNameGen), Gen.option(userLastNameGen))
       .flatMapN { case (id, f, l) =>
-        val e = (f, l).flatMapN(userEmailGen(_, _).generateOption)
+        val e = (f, l).flatMapN(userEmailGen(_, _).generateSome)
         User(id, f, l, e)
       }
-
-  extension [V](gen: Gen[V])
-    def generateOne: V = gen.sample.getOrElse(generateOne)
-    def generateOption: Option[V] = Gen.option(gen).sample.getOrElse(generateOption)
-    def generateAs[D](f: V => D): D = f(generateOne)

--- a/modules/search-solr-client/src/test/scala/io/renku/search/solr/client/SearchSolrClientSpec.scala
+++ b/modules/search-solr-client/src/test/scala/io/renku/search/solr/client/SearchSolrClientSpec.scala
@@ -20,6 +20,7 @@ package io.renku.search.solr.client
 
 import cats.effect.IO
 import cats.syntax.all.*
+import io.renku.search.GeneratorSyntax.*
 import io.renku.search.model.users
 import io.renku.search.query.Query
 import io.renku.search.solr.client.SearchSolrClientGenerators.*

--- a/modules/solr-client/src/main/scala/io/renku/solr/client/QueryData.scala
+++ b/modules/solr-client/src/main/scala/io/renku/solr/client/QueryData.scala
@@ -40,6 +40,8 @@ final case class QueryData(
   def withFields(field: FieldName*) = copy(fields = field)
   def addFilter(q: String): QueryData = copy(filter = filter :+ q)
   def withFacet(facet: Facets): QueryData = copy(facet = facet)
+  def withLimit(limit: Int): QueryData = copy(limit = limit)
+  def withOffset(offset: Int): QueryData = copy(offset = offset)
 
 object QueryData:
 

--- a/modules/solr-client/src/test/scala/io/renku/solr/client/SolrClientGenerator.scala
+++ b/modules/solr-client/src/test/scala/io/renku/solr/client/SolrClientGenerator.scala
@@ -25,8 +25,6 @@ import io.renku.search.model.CommonGenerators
 
 object SolrClientGenerator:
 
-  extension [V](gen: Gen[V]) def generateOne: V = gen.sample.getOrElse(generateOne)
-
   private val fieldNameString: Gen[String] =
     Gen.choose(4, 12).flatMap(n => Gen.listOfN(n, Gen.alphaLowerChar)).map(_.mkString)
 

--- a/modules/solr-client/src/test/scala/io/renku/solr/client/SolrClientSpec.scala
+++ b/modules/solr-client/src/test/scala/io/renku/solr/client/SolrClientSpec.scala
@@ -22,6 +22,7 @@ import cats.effect.IO
 import cats.syntax.all.*
 import io.bullet.borer.derivation.MapBasedCodecs
 import io.bullet.borer.{Decoder, Encoder}
+import io.renku.search.LoggingConfigure
 import io.renku.solr.client.SolrClientSpec.Room
 import io.renku.solr.client.schema.*
 import io.renku.solr.client.util.{SolrSpec, SolrTruncate}
@@ -35,6 +36,7 @@ import io.bullet.borer.derivation.key
 
 class SolrClientSpec
     extends CatsEffectSuite
+    with LoggingConfigure
     with ScalaCheckEffectSuite
     with SolrSpec
     with SolrTruncate:


### PR DESCRIPTION
- fixes the solr query generated when the user only specifies sort terms
- moves `def generateOne` extension methods to commons module
- adds a `LoggingConfigure` trait for tests to avoid logging too much stuff. If mixed in, the verbosity is set to `0` meaning only ERROR messages will be printed. It is not applied to all specs