### PR TITLE
feat: Use authenticated information to amend query

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,6 +55,7 @@ lazy val root = project
   )
   .aggregate(
     commons,
+    jwt,
     httpClient,
     events,
     redisClient,
@@ -98,6 +99,18 @@ lazy val commons = project
   )
   .enablePlugins(AutomateHeaderPlugin, BuildInfoPlugin)
   .disablePlugins(DbTestPlugin, RevolverPlugin)
+
+lazy val jwt = project
+  .in(file("modules/jwt"))
+  .enablePlugins(AutomateHeaderPlugin)
+  .disablePlugins(DbTestPlugin, RevolverPlugin)
+  .settings(commonSettings)
+  .settings(
+    name := "jwt",
+    description := "jwt with borer",
+    libraryDependencies ++= Dependencies.borer ++
+      Dependencies.jwtScala
+  )
 
 lazy val http4sBorer = project
   .in(file("modules/http4s-borer"))

--- a/build.sbt
+++ b/build.sbt
@@ -337,7 +337,8 @@ lazy val searchApi = project
     http4sBorer % "compile->compile;test->test",
     searchSolrClient % "compile->compile;test->test",
     configValues % "compile->compile;test->test",
-    searchQueryDocs % "compile->compile;test->test"
+    searchQueryDocs % "compile->compile;test->test",
+    jwt % "compile->compile;test->test"
   )
   .enablePlugins(AutomateHeaderPlugin, DockerImagePlugin, RevolverPlugin)
 

--- a/modules/commons/src/main/scala/io/renku/search/model/projects.scala
+++ b/modules/commons/src/main/scala/io/renku/search/model/projects.scala
@@ -63,22 +63,36 @@ object projects:
     given Transformer[Instant, CreationDate] = apply
     given Codec[CreationDate] = Codec.of[Instant]
 
-  enum Visibility derives Codec:
+  enum Visibility:
     lazy val name: String = productPrefix.toLowerCase
     case Public, Private
 
   object Visibility:
     given Order[Visibility] = Order.by(_.ordinal)
+    given Encoder[Visibility] = Encoder.forString.contramap(_.name)
+    given Decoder[Visibility] = Decoder.forString.mapEither(Visibility.fromString)
+
+    def fromString(v: String): Either[String, Visibility] =
+      Visibility.values
+        .find(_.name.equalsIgnoreCase(v))
+        .toRight(s"Invalid visibility: $v")
 
     def unsafeFromString(v: String): Visibility =
-      valueOf(v.toLowerCase.capitalize)
+      fromString(v).fold(sys.error, identity)
 
-  enum MemberRole derives Codec:
+  enum MemberRole:
     lazy val name: String = productPrefix.toLowerCase
     case Owner, Member
 
   object MemberRole:
     given Order[MemberRole] = Order.by(_.ordinal)
+    given Encoder[MemberRole] = Encoder.forString.contramap(_.name)
+    given Decoder[MemberRole] = Decoder.forString.mapEither(MemberRole.fromString)
+
+    def fromString(v: String): Either[String, MemberRole] =
+      MemberRole.values
+        .find(_.name.equalsIgnoreCase(v))
+        .toRight(s"Invalid member-role: $v")
 
     def unsafeFromString(v: String): MemberRole =
-      valueOf(v.toLowerCase.capitalize)
+      fromString(v).fold(sys.error, identity)

--- a/modules/commons/src/main/scala/io/renku/search/model/users.scala
+++ b/modules/commons/src/main/scala/io/renku/search/model/users.scala
@@ -42,4 +42,11 @@ object users:
     def apply(v: String): Email = v
     extension (self: Email) def value: String = self
     given Transformer[String, Email] = apply
-    given Codec[Email] = Codec.bimap[String, Email](_.value, LastName.apply)
+    given Codec[Email] = Codec.bimap[String, Email](_.value, Email.apply)
+
+  opaque type Username = String
+  object Username:
+    def apply(v: String): Username = v
+    extension (self: Username) def value: String = self
+    given Transformer[String, Username] = apply
+    given Codec[Username] = Codec.bimap[String, Username](_.value, Username.apply)

--- a/modules/jwt/src/main/scala/io/renku/search/jwt/BorerCodec.scala
+++ b/modules/jwt/src/main/scala/io/renku/search/jwt/BorerCodec.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2024 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.search.jwt
+
+import cats.syntax.all.*
+
+import io.bullet.borer.{Decoder, Reader}
+import pdi.jwt.{JwtAlgorithm, JwtClaim, JwtHeader}
+
+trait BorerCodec:
+  given Decoder[JwtAlgorithm] =
+    Decoder.forString.map(JwtAlgorithm.fromString)
+
+  given Decoder[JwtHeader] = new Decoder[JwtHeader]:
+    def read(r: Reader): JwtHeader =
+      r.readMapStart()
+      r.readUntilBreak(JwtHeader(None, None, None, None).withType) { h =>
+        r.readString() match
+          case "alg" =>
+            val alg = r.read[JwtAlgorithm]()
+            JwtHeader(alg.some, h.typ, h.contentType, h.keyId)
+          case "typ" => h.withType(r.readString())
+          case "cty" =>
+            JwtHeader(h.algorithm, h.typ, r.readString().some, h.keyId)
+          case "kid" => h.withKeyId(r.readString())
+          case _ =>
+            r.skipElement()
+            h
+      }
+
+  given Decoder[JwtClaim] = new Decoder[JwtClaim]:
+    def read(r: Reader): JwtClaim =
+      r.readMapStart()
+      r.readUntilBreak(JwtClaim()) { c =>
+        r.readString() match
+          case "iss" => c.copy(issuer = r.readStringOpt())
+          case "sub" => c.copy(subject = r.readStringOpt())
+          case "aud" => c.copy(audience = r.readSetStr())
+          case "exp" => c.copy(expiration = r.readLongOpt())
+          case "nbf" => c.copy(notBefore = r.readLongOpt())
+          case "iat" => c.copy(issuedAt = r.readLongOpt())
+          case "jti" => c.copy(jwtId = r.readStringOpt())
+          case _ =>
+            r.skipElement()
+            c
+      }
+
+  extension (self: Reader)
+    def readStringOpt(): Option[String] =
+      if (self.tryReadNull()) None else self.readString().some
+
+    def readLongOpt(): Option[Long] =
+      if (self.tryReadNull()) None else self.readLong().some
+
+    def readSetStr(): Option[Set[String]] =
+      if (self.tryReadNull()) None
+      else if (self.hasArrayStart) self.read[Set[String]]().some
+      else Set(self.readString()).some
+
+  extension (self: JwtClaim)
+    def copy(
+        issuer: Option[String] = self.issuer,
+        subject: Option[String] = self.subject,
+        audience: Option[Set[String]] = self.audience,
+        expiration: Option[Long] = self.expiration,
+        notBefore: Option[Long] = self.notBefore,
+        issuedAt: Option[Long] = self.issuedAt,
+        jwtId: Option[String] = self.jwtId
+    ): JwtClaim =
+      JwtClaim(
+        self.content,
+        issuer,
+        subject,
+        audience,
+        expiration,
+        notBefore,
+        issuedAt,
+        jwtId
+      )

--- a/modules/jwt/src/main/scala/io/renku/search/jwt/JwtBorer.scala
+++ b/modules/jwt/src/main/scala/io/renku/search/jwt/JwtBorer.scala
@@ -47,6 +47,5 @@ class JwtBorer(override val clock: Clock)
   def decodeNoSignatureCheck(token: String): Try[JwtClaim] =
     decode(token, noSigOptions)
 
-
 object JwtBorer extends JwtBorer(Clock.systemUTC()):
   def apply(clock: Clock): JwtBorer = new JwtBorer(clock)

--- a/modules/jwt/src/main/scala/io/renku/search/jwt/JwtBorer.scala
+++ b/modules/jwt/src/main/scala/io/renku/search/jwt/JwtBorer.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.search.jwt
+
+import java.time.Clock
+
+import scala.util.Try
+
+import io.bullet.borer.Json
+import pdi.jwt.*
+
+class JwtBorer(override val clock: Clock)
+    extends JwtCore[JwtHeader, JwtClaim]
+    with BorerCodec:
+  private val noSigOptions = JwtOptions.DEFAULT.copy(signature = false)
+
+  protected def parseHeader(header: String): JwtHeader =
+    Json.decode(header.getBytes).to[JwtHeader].value
+
+  protected def parseClaim(claim: String): JwtClaim =
+    Json.decode(claim.getBytes).to[JwtClaim].value
+
+  protected def extractAlgorithm(header: JwtHeader): Option[JwtAlgorithm] =
+    header.algorithm
+  protected def extractExpiration(claim: JwtClaim): Option[Long] = claim.expiration
+  protected def extractNotBefore(claim: JwtClaim): Option[Long] = claim.notBefore
+
+  def decodeAllNoSignatureCheck(token: String): Try[(JwtHeader, JwtClaim, String)] =
+    decodeAll(token, noSigOptions)
+
+  def decodeNoSignatureCheck(token: String): Try[JwtClaim] =
+    decode(token, noSigOptions)
+
+
+object JwtBorer extends JwtBorer(Clock.systemUTC()):
+  def apply(clock: Clock): JwtBorer = new JwtBorer(clock)

--- a/modules/jwt/src/test/scala/io/renku/search/jwt/JwtBorerSpec.scala
+++ b/modules/jwt/src/test/scala/io/renku/search/jwt/JwtBorerSpec.scala
@@ -24,8 +24,9 @@ import pdi.jwt.JwtAlgorithm
 
 class JwtBorerSpec extends FunSuite:
 
-  val secret =  new javax.crypto.spec.SecretKeySpec("abcdefg".getBytes, "HS256")
-  val exampleToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJteS11c2VyLWlkIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.d7F1v9sfcQzVrEGXXhJoGukbfXhm3zKn0fUyvFAMzm0"
+  val secret = new javax.crypto.spec.SecretKeySpec("abcdefg".getBytes, "HS256")
+  val exampleToken =
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJteS11c2VyLWlkIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.d7F1v9sfcQzVrEGXXhJoGukbfXhm3zKn0fUyvFAMzm0"
 
   val regexDecode = Jwt.decodeAll(exampleToken, secret).get
 

--- a/modules/jwt/src/test/scala/io/renku/search/jwt/JwtBorerSpec.scala
+++ b/modules/jwt/src/test/scala/io/renku/search/jwt/JwtBorerSpec.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.search.jwt
+
+import munit.FunSuite
+import pdi.jwt.Jwt
+import pdi.jwt.JwtAlgorithm
+
+class JwtBorerSpec extends FunSuite:
+
+  val secret =  new javax.crypto.spec.SecretKeySpec("abcdefg".getBytes, "HS256")
+  val exampleToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJteS11c2VyLWlkIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.d7F1v9sfcQzVrEGXXhJoGukbfXhm3zKn0fUyvFAMzm0"
+
+  val regexDecode = Jwt.decodeAll(exampleToken, secret).get
+
+  test("decode"):
+    val (header, claim, _) = JwtBorer.decodeAll(exampleToken, secret).get
+    assertEquals(header.algorithm, Some(JwtAlgorithm.HS256))
+    assertEquals(header.typ, Some("JWT"))
+    assertEquals(header.keyId, None)
+    assertEquals(header.contentType, None)
+
+    assertEquals(claim.subject, Some("my-user-id"))
+    assertEquals(claim.issuedAt, Some(1516239022L))
+    assertEquals(header, regexDecode._1)
+    assertEquals(claim, regexDecode._2.withContent("{}"))
+
+  test("decode without secret"):
+    val (header, claim, _) = JwtBorer.decodeAllNoSignatureCheck(exampleToken).get
+    val claim2 = JwtBorer.decodeNoSignatureCheck(exampleToken).get
+    assertEquals(claim, claim2)
+    assertEquals(header, regexDecode._1)
+    assertEquals(claim, regexDecode._2.withContent("{}"))

--- a/modules/search-api/src/main/scala/io/renku/search/api/SearchApi.scala
+++ b/modules/search-api/src/main/scala/io/renku/search/api/SearchApi.scala
@@ -25,7 +25,7 @@ import io.renku.solr.client.SolrConfig
 import io.renku.search.api.data.*
 
 trait SearchApi[F[_]]:
-  def query(query: QueryInput): F[Either[String, SearchResult]]
+  def query(auth: AuthContext)(query: QueryInput): F[Either[String, SearchResult]]
 
 object SearchApi:
   def apply[F[_]: Async: Network](

--- a/modules/search-api/src/main/scala/io/renku/search/api/data/AuthContext.scala
+++ b/modules/search-api/src/main/scala/io/renku/search/api/data/AuthContext.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.search.api.data
+
+import cats.Show
+import cats.syntax.all.*
+
+import io.renku.search.jwt.JwtBorer
+import io.renku.search.model.Id
+import io.renku.search.solr.SearchRole
+import pdi.jwt.JwtClaim
+
+sealed trait AuthContext:
+  def isAnonymous: Boolean
+  def isAuthenticated: Boolean = !isAnonymous
+  def fold[A](
+      fa: AuthContext.Authenticated => A,
+      fb: AuthContext.AnonymousId => A,
+      fc: => A
+  ): A
+  def authenticated: Option[AuthContext.Authenticated]
+  def searchRole: SearchRole =
+    fold(a => SearchRole.user(a.userId), _ => SearchRole.Anonymous, SearchRole.Anonymous)
+  def render: String
+
+object AuthContext:
+  val anonymous: AuthContext = Anonymous
+  def anonymousId(anonId: String): AuthContext = AnonymousId(Id(anonId))
+  def authenticated(userId: Id): AuthContext = Authenticated(userId)
+
+  case object Anonymous extends AuthContext {
+    val isAnonymous = true
+    val authenticated: Option[Authenticated] = None
+    val render = ""
+    def fold[A](
+        fa: AuthContext.Authenticated => A,
+        fb: AuthContext.AnonymousId => A,
+        fc: => A
+    ): A = fc
+  }
+
+  final case class AnonymousId(anonId: Id) extends AuthContext {
+    val isAnonymous = true
+    def fold[A](
+        fa: AuthContext.Authenticated => A,
+        fb: AuthContext.AnonymousId => A,
+        fc: => A
+    ): A = fb(this)
+    val authenticated: Option[Authenticated] = None
+    val render = anonId.value
+  }
+  final case class Authenticated(userId: Id) extends AuthContext:
+    val isAnonymous = false
+    val authenticated: Option[AuthContext.Authenticated] = Some(this)
+    def fold[A](
+        fa: AuthContext.Authenticated => A,
+        fb: AuthContext.AnonymousId => A,
+        fc: => A
+    ): A = fa(this)
+    def render = JwtBorer.encode(JwtClaim(subject = userId.value.some))
+
+  given Show[AuthContext] = Show.show {
+    case Authenticated(id) => s"Authenticated(${id.value})"
+    case AnonymousId(id)   => s"AnonymousId(${id.value})"
+    case Anonymous         => "Anonymous"
+  }

--- a/modules/search-api/src/test/scala/io/renku/search/api/SearchApiSpec.scala
+++ b/modules/search-api/src/test/scala/io/renku/search/api/SearchApiSpec.scala
@@ -32,6 +32,8 @@ import io.renku.search.solr.client.SolrDocumentGenerators.*
 import io.renku.search.solr.documents.{EntityDocument, User as SolrUser}
 import munit.CatsEffectSuite
 import scribe.Scribe
+import org.scalacheck.Gen
+import io.renku.search.model.projects.Visibility
 
 class SearchApiSpec extends CatsEffectSuite with SearchSolrSpec:
 
@@ -39,22 +41,38 @@ class SearchApiSpec extends CatsEffectSuite with SearchSolrSpec:
 
   test("do a lookup in Solr to find entities matching the given phrase"):
     withSearchSolrClient().use { client =>
-      val project1 = projectDocumentGen("matching", "matching description").generateOne
-      val project2 = projectDocumentGen("disparate", "disparate description").generateOne
+      val project1 = projectDocumentGen(
+        "matching",
+        "matching description",
+        Gen.const(Visibility.Public)
+      ).generateOne
+      val project2 = projectDocumentGen(
+        "disparate",
+        "disparate description",
+        Gen.const(Visibility.Public)
+      ).generateOne
       val searchApi = new SearchApiImpl[IO](client)
       for {
         _ <- client.insert((project1 :: project2 :: Nil).map(_.widen))
         results <- searchApi
           .query(AuthContext.anonymous)(mkQuery("matching"))
           .map(_.fold(err => fail(s"Calling Search API failed with $err"), identity))
-      } yield assert {
-        results.items.map(scoreToNone) contains toApiEntity(project1)
-      }
+
+        expected = toApiEntities(project1).toSet
+        obtained = results.items.map(scoreToNone).toSet
+      } yield assert(
+        expected.diff(obtained).isEmpty,
+        s"Expected $expected, bot got $obtained"
+      )
     }
 
   test("return Project and User entities"):
     withSearchSolrClient().use { client =>
-      val project = projectDocumentGen("exclusive", "exclusive description").generateOne
+      val project = projectDocumentGen(
+        "exclusive",
+        "exclusive description",
+        Gen.const(Visibility.Public)
+      ).generateOne
       val user = SolrUser(project.createdBy, FirstName("exclusive").some)
       val searchApi = new SearchApiImpl[IO](client)
       for {
@@ -62,9 +80,13 @@ class SearchApiSpec extends CatsEffectSuite with SearchSolrSpec:
         results <- searchApi
           .query(AuthContext.anonymous)(mkQuery("exclusive"))
           .map(_.fold(err => fail(s"Calling Search API failed with $err"), identity))
-      } yield assert {
-        toApiEntities(project, user).diff(results.items.map(scoreToNone)).isEmpty
-      }
+
+        expected = toApiEntities(project, user).toSet
+        obtained = results.items.map(scoreToNone).toSet
+      } yield assert(
+        expected.diff(obtained).isEmpty,
+        s"Expected $expected, bot got $obtained"
+      )
     }
 
   private def scoreToNone(e: SearchEntity): SearchEntity = e match

--- a/modules/search-api/src/test/scala/io/renku/search/api/SearchApiSpec.scala
+++ b/modules/search-api/src/test/scala/io/renku/search/api/SearchApiSpec.scala
@@ -45,7 +45,7 @@ class SearchApiSpec extends CatsEffectSuite with SearchSolrSpec:
       for {
         _ <- client.insert((project1 :: project2 :: Nil).map(_.widen))
         results <- searchApi
-          .query(mkQuery("matching"))
+          .query(AuthContext.anonymous)(mkQuery("matching"))
           .map(_.fold(err => fail(s"Calling Search API failed with $err"), identity))
       } yield assert {
         results.items.map(scoreToNone) contains toApiEntity(project1)
@@ -60,7 +60,7 @@ class SearchApiSpec extends CatsEffectSuite with SearchSolrSpec:
       for {
         _ <- client.insert(project :: user :: Nil)
         results <- searchApi
-          .query(mkQuery("exclusive"))
+          .query(AuthContext.anonymous)(mkQuery("exclusive"))
           .map(_.fold(err => fail(s"Calling Search API failed with $err"), identity))
       } yield assert {
         toApiEntities(project, user).diff(results.items.map(scoreToNone)).isEmpty

--- a/modules/search-provision/src/main/scala/io/renku/search/provision/handler/DocumentConverter.scala
+++ b/modules/search-provision/src/main/scala/io/renku/search/provision/handler/DocumentConverter.scala
@@ -51,8 +51,7 @@ object DocumentConverter:
     fromTransformer(
       _.into[UserDocument].transform(
         Field.default(_.score),
-        Field.computed(_.name, u => UserDocument.nameFrom(u.firstName, u.lastName)),
-        Field.default(_.visibility)
+        Field.computed(_.name, u => UserDocument.nameFrom(u.firstName, u.lastName))
       )
     )
 

--- a/modules/search-provision/src/main/scala/io/renku/search/provision/handler/DocumentUpdates.scala
+++ b/modules/search-provision/src/main/scala/io/renku/search/provision/handler/DocumentUpdates.scala
@@ -50,8 +50,7 @@ object DocumentUpdates:
         .into[UserDocument]
         .transform(
           Field.default(_.score),
-          Field.computed(_.name, u => UserDocument.nameFrom(u.firstName, u.lastName)),
-          Field.default(_.visibility)
+          Field.computed(_.name, u => UserDocument.nameFrom(u.firstName, u.lastName))
         )
         .some
     case _ => None

--- a/modules/search-provision/src/main/scala/io/renku/search/provision/handler/FetchFromSolr.scala
+++ b/modules/search-provision/src/main/scala/io/renku/search/provision/handler/FetchFromSolr.scala
@@ -30,6 +30,7 @@ import io.renku.search.solr.documents.EntityDocument
 import io.renku.search.query.Query
 import io.bullet.borer.derivation.MapBasedCodecs
 import io.bullet.borer.Decoder
+import io.renku.search.solr.SearchRole
 import io.renku.search.solr.schema.EntityDocumentSchema.Fields
 import io.renku.solr.client.QueryString
 import io.renku.solr.client.QueryData
@@ -94,7 +95,7 @@ object FetchFromSolr:
           val loaded = ids
             .traverse(id =>
               solrClient
-                .queryEntity(idQuery(id), 1, 0)
+                .queryEntity(SearchRole.Admin, idQuery(id), 1, 0)
                 .map(_.responseBody.docs.headOption)
                 .map(doc => id -> doc)
             )

--- a/modules/search-provision/src/main/scala/io/renku/search/provision/handler/FetchFromSolr.scala
+++ b/modules/search-provision/src/main/scala/io/renku/search/provision/handler/FetchFromSolr.scala
@@ -71,8 +71,7 @@ object FetchFromSolr:
       val logger = scribe.cats.effect[F]
 
       private def idQuery(id: Id): Query =
-        // TODO this must be renamed to "idIs" since we have only one id type
-        Query(Query.Segment.projectIdIs(id.value))
+        Query(Query.Segment.idIs(id.value))
 
       def fetchProjectForUser(userId: Id): Stream[F, FetchFromSolr.ProjectId] =
         val query = QueryString(

--- a/modules/search-provision/src/test/scala/io/renku/search/provision/user/UserSyntax.scala
+++ b/modules/search-provision/src/test/scala/io/renku/search/provision/user/UserSyntax.scala
@@ -29,8 +29,7 @@ trait UserSyntax:
       .into[User]
       .transform(
         Field.default(_.score),
-        Field.computed(_.name, u => User.nameFrom(u.firstName, u.lastName)),
-        Field.default(_.visibility)
+        Field.computed(_.name, u => User.nameFrom(u.firstName, u.lastName))
       )
     def update(updated: UserUpdated): UserAdded =
       added.copy(

--- a/modules/search-query-docs/docs/manual.md
+++ b/modules/search-query-docs/docs/manual.md
@@ -38,36 +38,6 @@ numpy flight visibility:public,private
 Searches for entities containing `numpy` _and_ `flight` that are
 _either_ `public` _or_ `private`.
 
-### Query JSON
-
-The JSON format allows to specify the same query as a JSON object. A
-JSON object may contain specific terms by including the corresponding
-field-value pair. For unspecific terms, the special field `_text` is
-used.
-
-Example:
-```json
-{
-  "_text": "numpy flight",
-  "visibility": "public"
-}
-```
-
-JSON objects are sequences of key-value pairs. As such, the encoding
-allows to specifiy multiple same named fields in one JSON object. This
-would be a valid query:
-
-```json
-{
-  "_text": "numpy",
-  "visibility": "public",
-  "_text": "flight"
-}
-```
-
-The JSON variant follows the same rules for specifying field values.
-Multiple alternative values can be given as a comma separated list.
-
 ### Fields
 
 The following fields are available:

--- a/modules/search-query/src/main/scala/io/renku/search/query/Field.scala
+++ b/modules/search-query/src/main/scala/io/renku/search/query/Field.scala
@@ -21,7 +21,7 @@ package io.renku.search.query
 import io.bullet.borer.{Decoder, Encoder}
 
 enum Field:
-  case ProjectId
+  case Id
   case Name
   case Slug
   case Visibility

--- a/modules/search-query/src/main/scala/io/renku/search/query/FieldTerm.scala
+++ b/modules/search-query/src/main/scala/io/renku/search/query/FieldTerm.scala
@@ -25,8 +25,7 @@ import io.renku.search.model.projects.Visibility
 enum FieldTerm(val field: Field, val cmp: Comparison):
   case TypeIs(values: NonEmptyList[EntityType])
       extends FieldTerm(Field.Type, Comparison.Is)
-  case ProjectIdIs(values: NonEmptyList[String])
-      extends FieldTerm(Field.ProjectId, Comparison.Is)
+  case IdIs(values: NonEmptyList[String]) extends FieldTerm(Field.Id, Comparison.Is)
   case NameIs(values: NonEmptyList[String]) extends FieldTerm(Field.Name, Comparison.Is)
   case SlugIs(values: NonEmptyList[String]) extends FieldTerm(Field.Slug, Comparison.Is)
   case VisibilityIs(values: NonEmptyList[Visibility])
@@ -41,9 +40,9 @@ enum FieldTerm(val field: Field, val cmp: Comparison):
       case TypeIs(values) =>
         val ts = values.toList.distinct.map(_.name)
         ts.mkString(",")
-      case ProjectIdIs(values) => FieldTerm.nelToString(values)
-      case NameIs(values)      => FieldTerm.nelToString(values)
-      case SlugIs(values)      => FieldTerm.nelToString(values)
+      case IdIs(values)   => FieldTerm.nelToString(values)
+      case NameIs(values) => FieldTerm.nelToString(values)
+      case SlugIs(values) => FieldTerm.nelToString(values)
       case VisibilityIs(values) =>
         val vis = values.toList.distinct.map(_.name)
         vis.mkString(",")

--- a/modules/search-query/src/main/scala/io/renku/search/query/Query.scala
+++ b/modules/search-query/src/main/scala/io/renku/search/query/Query.scala
@@ -80,8 +80,8 @@ object Query:
     def typeIs(value: EntityType, more: EntityType*): Segment =
       Segment.Field(FieldTerm.TypeIs(NonEmptyList(value, more.toList)))
 
-    def projectIdIs(value: String, more: String*): Segment =
-      Segment.Field(FieldTerm.ProjectIdIs(NonEmptyList(value, more.toList)))
+    def idIs(value: String, more: String*): Segment =
+      Segment.Field(FieldTerm.IdIs(NonEmptyList(value, more.toList)))
 
     def nameIs(value: String, more: String*): Segment =
       Segment.Field(FieldTerm.NameIs(NonEmptyList(value, more.toList)))

--- a/modules/search-query/src/main/scala/io/renku/search/query/json/QueryJsonCodec.scala
+++ b/modules/search-query/src/main/scala/io/renku/search/query/json/QueryJsonCodec.scala
@@ -35,8 +35,8 @@ import scala.collection.mutable.ListBuffer
   * {{{
   *  [
   *   {
-  *     "projectId": ["p1", "p2"],
-  *     "projectId": "p2",
+  *     "id": ["p1", "p2"],
+  *     "id": "p2",
   *     "name": "test",
   *     "_text": "some phrase",
   *     "creationDate": ["<", "2024-01-29T12:00"]
@@ -69,7 +69,7 @@ private[query] object QueryJsonCodec:
       case FieldTerm.TypeIs(values) =>
         writeNelValue(w, values)
 
-      case FieldTerm.ProjectIdIs(values) =>
+      case FieldTerm.IdIs(values) =>
         writeNelValue(w, values)
 
       case FieldTerm.NameIs(values) =>
@@ -117,9 +117,9 @@ private[query] object QueryJsonCodec:
         val values = readNel[EntityType](r)
         Segment.Field(TypeIs(values))
 
-      case Name.FieldName(Field.ProjectId) =>
+      case Name.FieldName(Field.Id) =>
         val values = readNel[String](r)
-        Segment.Field(ProjectIdIs(values))
+        Segment.Field(IdIs(values))
 
       case Name.FieldName(Field.Name) =>
         val values = readNel[String](r)

--- a/modules/search-query/src/main/scala/io/renku/search/query/parse/QueryParser.scala
+++ b/modules/search-query/src/main/scala/io/renku/search/query/parse/QueryParser.scala
@@ -107,7 +107,7 @@ private[query] object QueryParser {
     ((field <* is) ~ values).map { case (f, v) =>
       f match
         case Field.Name      => FieldTerm.NameIs(v)
-        case Field.ProjectId => FieldTerm.ProjectIdIs(v)
+        case Field.Id        => FieldTerm.IdIs(v)
         case Field.Slug      => FieldTerm.SlugIs(v)
         case Field.CreatedBy => FieldTerm.CreatedByIs(v)
         // other fields are excluded from the field list above

--- a/modules/search-query/src/test/scala/io/renku/search/query/QueryGenerators.scala
+++ b/modules/search-query/src/test/scala/io/renku/search/query/QueryGenerators.scala
@@ -115,7 +115,7 @@ object QueryGenerators:
     Gen.choose(1, 4).flatMap(n => CommonGenerators.nelOfN(n, phrase))
 
   val projectIdTerm: Gen[FieldTerm] =
-    stringValues.map(FieldTerm.ProjectIdIs(_))
+    stringValues.map(FieldTerm.IdIs(_))
 
   val nameTerm: Gen[FieldTerm] =
     stringValues.map(FieldTerm.NameIs(_))

--- a/modules/search-query/src/test/scala/io/renku/search/query/parse/QueryParserSpec.scala
+++ b/modules/search-query/src/test/scala/io/renku/search/query/parse/QueryParserSpec.scala
@@ -52,8 +52,8 @@ class QueryParserSpec extends ScalaCheckSuite with ParserSuite {
 
   test("field name") {
     val p = QueryParser.fieldNameFrom(Field.values.toSet)
-    List("projectId", "projectid").foreach { s =>
-      assertEquals(p.run(s), Field.ProjectId)
+    List("createdBy", "createdby").foreach { s =>
+      assertEquals(p.run(s), Field.CreatedBy)
     }
     Field.values.foreach { f =>
       assertEquals(p.run(f.name), f)
@@ -81,7 +81,7 @@ class QueryParserSpec extends ScalaCheckSuite with ParserSuite {
   test("field term") {
     val p = QueryParser.fieldTerm
     val data = List(
-      "projectId:id5" -> FieldTerm.ProjectIdIs(Nel.of("id5")),
+      "id:id5" -> FieldTerm.IdIs(Nel.of("id5")),
       "name:\"my project\"" -> FieldTerm.NameIs(Nel.of("my project")),
       "slug:ab1,ab2" -> FieldTerm.SlugIs(Nel.of("ab1", "ab2")),
       "type:project" -> FieldTerm.TypeIs(Nel.of(EntityType.Project))
@@ -98,8 +98,8 @@ class QueryParserSpec extends ScalaCheckSuite with ParserSuite {
       Query.Segment.Text("hello")
     )
     assertEquals(
-      p.run("projectId:id5"),
-      Query.Segment.Field(FieldTerm.ProjectIdIs(Nel.of("id5")))
+      p.run("id:id5"),
+      Query.Segment.Field(FieldTerm.IdIs(Nel.of("id5")))
     )
     assertEquals(
       p.run("foo:bar"),
@@ -109,8 +109,8 @@ class QueryParserSpec extends ScalaCheckSuite with ParserSuite {
 
   test("invalid field terms converted as text".ignore) {
     assertEquals(
-      Query.parse("projectId:"),
-      Right(Query(Segment.Text("projectId:")))
+      Query.parse("id:"),
+      Right(Query(Segment.Text("id:")))
     )
     assertEquals(
       Query.parse("projectId1"),

--- a/modules/search-solr-client/src/main/scala/io/renku/search/solr/SearchRole.scala
+++ b/modules/search-solr-client/src/main/scala/io/renku/search/solr/SearchRole.scala
@@ -16,24 +16,16 @@
  * limitations under the License.
  */
 
-package io.renku.search.api.data
+package io.renku.search.solr
 
-import io.renku.search.query.Query
-import io.bullet.borer.Encoder
-import io.bullet.borer.derivation.MapBasedCodecs.{deriveDecoder, deriveEncoder}
-import io.bullet.borer.Decoder
-import cats.Show
+import io.renku.search.model.Id
 
-final case class QueryInput(
-    query: Query,
-    page: PageDef
-)
+enum SearchRole:
+  case Admin
+  case User(id: Id)
+  case Anonymous
 
-object QueryInput:
-  given Encoder[QueryInput] = deriveEncoder
-  given Decoder[QueryInput] = deriveDecoder
-
-  given Show[QueryInput] = Show.show(i => s"(${i.query.render}, ${i.page})")
-
-  def pageOne(query: Query): QueryInput =
-    QueryInput(query, PageDef.default)
+object SearchRole:
+  val admin: SearchRole = Admin
+  val anonymous: SearchRole = Anonymous
+  def user(id: Id): SearchRole = User(id)

--- a/modules/search-solr-client/src/main/scala/io/renku/search/solr/client/SearchSolrClient.scala
+++ b/modules/search-solr-client/src/main/scala/io/renku/search/solr/client/SearchSolrClient.scala
@@ -18,24 +18,31 @@
 
 package io.renku.search.solr.client
 
+import scala.reflect.ClassTag
+
 import cats.data.NonEmptyList
 import cats.effect.{Async, Resource}
-import fs2.io.net.Network
 import fs2.Stream
+import fs2.io.net.Network
+
 import io.bullet.borer.{Decoder, Encoder}
 import io.renku.search.model.Id
 import io.renku.search.query.Query
+import io.renku.search.solr.SearchRole
 import io.renku.search.solr.documents.EntityDocument
-import io.renku.solr.client.{QueryData, QueryResponse, SolrClient, SolrConfig}
-
-import scala.reflect.ClassTag
+import io.renku.solr.client.*
 
 trait SearchSolrClient[F[_]]:
   def findById[D <: EntityDocument](id: Id)(using ct: ClassTag[D]): F[Option[D]]
   def insert[D: Encoder](documents: Seq[D]): F[Unit]
   def deleteIds(ids: NonEmptyList[Id]): F[Unit]
-  def queryEntity(query: Query, limit: Int, offset: Int): F[QueryResponse[EntityDocument]]
   def query[D: Decoder](query: QueryData): F[QueryResponse[D]]
+  def queryEntity(
+      role: SearchRole,
+      query: Query,
+      limit: Int,
+      offset: Int
+  ): F[QueryResponse[EntityDocument]]
   def queryAll[D: Decoder](query: QueryData): Stream[F, D]
 
 object SearchSolrClient:

--- a/modules/search-solr-client/src/main/scala/io/renku/search/solr/documents/EntityDocument.scala
+++ b/modules/search-solr-client/src/main/scala/io/renku/search/solr/documents/EntityDocument.scala
@@ -25,6 +25,8 @@ import io.renku.search.model.projects.MemberRole
 import io.renku.search.model.projects.MemberRole.{Member, Owner}
 import io.renku.solr.client.EncoderSupport.*
 import io.renku.search.model.projects.Visibility
+import io.renku.search.solr.schema.EntityDocumentSchema.Fields
+import io.renku.solr.client.EncoderSupport
 
 sealed trait EntityDocument:
   val score: Option[Double]
@@ -77,12 +79,14 @@ final case class User(
     firstName: Option[users.FirstName] = None,
     lastName: Option[users.LastName] = None,
     name: Option[Name] = None,
-    score: Option[Double] = None,
-    visibility: Visibility = Visibility.Public
+    score: Option[Double] = None
 ) extends EntityDocument
 
 object User:
   val entityType: String = "User"
+  // auto-add a visibility:public to users
+  given Encoder[User] =
+    EncoderSupport.deriveWithAdditional(Fields.visibility.name, Visibility.Public)
 
   def nameFrom(firstName: Option[String], lastName: Option[String]): Option[Name] =
     Option(List(firstName, lastName).flatten.mkString(" "))

--- a/modules/search-solr-client/src/main/scala/io/renku/search/solr/query/LuceneQueryEncoders.scala
+++ b/modules/search-solr-client/src/main/scala/io/renku/search/solr/query/LuceneQueryEncoders.scala
@@ -30,9 +30,9 @@ import io.renku.search.query.Comparison
 
 trait LuceneQueryEncoders:
 
-  given projectIdIs[F[_]: Applicative]: SolrTokenEncoder[F, FieldTerm.ProjectIdIs] =
-    SolrTokenEncoder.basic { case FieldTerm.ProjectIdIs(ids) =>
-      SolrQuery(SolrToken.orFieldIs(Field.ProjectId, ids.map(SolrToken.fromString)))
+  given projectIdIs[F[_]: Applicative]: SolrTokenEncoder[F, FieldTerm.IdIs] =
+    SolrTokenEncoder.basic { case FieldTerm.IdIs(ids) =>
+      SolrQuery(SolrToken.orFieldIs(Field.Id, ids.map(SolrToken.fromString)))
     }
 
   given nameIs[F[_]: Applicative]: SolrTokenEncoder[F, FieldTerm.NameIs] =

--- a/modules/search-solr-client/src/main/scala/io/renku/search/solr/query/QueryInterpreter.scala
+++ b/modules/search-solr-client/src/main/scala/io/renku/search/solr/query/QueryInterpreter.scala
@@ -19,14 +19,15 @@
 package io.renku.search.solr.query
 
 import io.renku.search.query.Query
+import io.renku.search.solr.SearchRole
 
 trait QueryInterpreter[F[_]]:
-  def run(ctx: Context[F], q: Query): F[SolrQuery]
+  def run(ctx: Context[F], role: SearchRole, q: Query): F[SolrQuery]
 
 object QueryInterpreter:
   trait WithContext[F[_]]:
-    def run(q: Query): F[SolrQuery]
+    def run(role: SearchRole, q: Query): F[SolrQuery]
 
   def withContext[F[_]](qi: QueryInterpreter[F], ctx: Context[F]): WithContext[F] =
     new WithContext[F]:
-      def run(q: Query) = qi.run(ctx, q)
+      def run(role: SearchRole, q: Query) = qi.run(ctx, role, q)

--- a/modules/search-solr-client/src/main/scala/io/renku/search/solr/query/SolrQuery.scala
+++ b/modules/search-solr-client/src/main/scala/io/renku/search/solr/query/SolrQuery.scala
@@ -20,6 +20,8 @@ package io.renku.search.solr.query
 
 import cats.Monoid
 import cats.syntax.all.*
+
+import io.renku.search.model.Id
 import io.renku.search.query.Order
 import io.renku.solr.client.SolrSort
 
@@ -30,6 +32,12 @@ final case class SolrQuery(
   def withQuery(q: SolrToken): SolrQuery = copy(query = q)
   def ++(next: SolrQuery): SolrQuery =
     SolrQuery(query && next.query, sort ++ next.sort)
+
+  def asAnonymous: SolrQuery =
+    SolrQuery(query.parens && SolrToken.publicOnly, sort)
+
+  def asUser(id: Id): SolrQuery =
+    SolrQuery(query.parens && SolrToken.forUser(id), sort)
 
 object SolrQuery:
   val empty: SolrQuery = SolrQuery(SolrToken.empty, SolrSort.empty)

--- a/modules/search-solr-client/src/main/scala/io/renku/search/solr/query/SolrToken.scala
+++ b/modules/search-solr-client/src/main/scala/io/renku/search/solr/query/SolrToken.scala
@@ -45,7 +45,7 @@ object SolrToken:
 
   def fromField(field: Field): SolrToken =
     (field match
-      case Field.ProjectId  => SolrField.id
+      case Field.Id         => SolrField.id
       case Field.Name       => SolrField.name
       case Field.Slug       => SolrField.slug
       case Field.Visibility => SolrField.visibility

--- a/modules/search-solr-client/src/test/scala/io/renku/search/solr/client/SearchSolrClientSpec.scala
+++ b/modules/search-solr-client/src/test/scala/io/renku/search/solr/client/SearchSolrClientSpec.scala
@@ -25,6 +25,7 @@ import io.bullet.borer.derivation.MapBasedCodecs.deriveDecoder
 import io.renku.search.GeneratorSyntax.*
 import io.renku.search.model.users
 import io.renku.search.query.Query
+import io.renku.search.solr.SearchRole
 import io.renku.search.solr.client.SolrDocumentGenerators.*
 import io.renku.search.solr.documents.EntityOps.*
 import io.renku.search.solr.documents.{EntityDocument, Project, User}
@@ -40,7 +41,12 @@ class SearchSolrClientSpec extends CatsEffectSuite with SearchSolrSpec:
         projectDocumentGen("solr-project", "solr project description").generateOne
       for {
         _ <- client.insert(Seq(project.widen))
-        qr <- client.queryEntity(Query.parse("solr").toOption.get, 10, 0)
+        qr <- client.queryEntity(
+          SearchRole.Admin,
+          Query.parse("solr").toOption.get,
+          10,
+          0
+        )
         _ = assert(qr.responseBody.docs.map(_.noneScore) contains project)
         gr <- client.findById[Project](project.id)
         _ = assert(gr contains project)
@@ -53,7 +59,12 @@ class SearchSolrClientSpec extends CatsEffectSuite with SearchSolrSpec:
       val user = userDocumentGen.generateOne.copy(firstName = firstName.some)
       for {
         _ <- client.insert(Seq(user.widen))
-        qr <- client.queryEntity(Query.parse(firstName.value).toOption.get, 10, 0)
+        qr <- client.queryEntity(
+          SearchRole.Admin,
+          Query.parse(firstName.value).toOption.get,
+          10,
+          0
+        )
         _ = assert(qr.responseBody.docs.map(_.noneScore) contains user)
         gr <- client.findById[User](user.id)
         _ = assert(gr contains user)

--- a/modules/search-solr-client/src/test/scala/io/renku/search/solr/client/SolrDocumentGenerators.scala
+++ b/modules/search-solr-client/src/test/scala/io/renku/search/solr/client/SolrDocumentGenerators.scala
@@ -25,6 +25,7 @@ import io.renku.search.model.ModelGenerators.*
 import io.renku.search.solr.documents.*
 import org.scalacheck.Gen
 import org.scalacheck.cats.implicits.*
+import io.renku.search.model.projects.Visibility
 
 object SolrDocumentGenerators extends SolrDocumentGenerators
 
@@ -40,8 +41,12 @@ trait SolrDocumentGenerators:
       s"proj desc $differentiator"
     )
 
-  def projectDocumentGen(name: String, desc: String): Gen[Project] =
-    (projectIdGen, idGen, projectVisibilityGen, projectCreationDateGen)
+  def projectDocumentGen(
+      name: String,
+      desc: String,
+      visibilityGen: Gen[Visibility] = projectVisibilityGen
+  ): Gen[Project] =
+    (projectIdGen, idGen, visibilityGen, projectCreationDateGen)
       .mapN((projectId, creatorId, visibility, creationDate) =>
         Project(
           projectId,

--- a/modules/search-solr-client/src/test/scala/io/renku/search/solr/query/AuthTestData.scala
+++ b/modules/search-solr-client/src/test/scala/io/renku/search/solr/query/AuthTestData.scala
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2024 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.search.solr.query
+
+import cats.effect.IO
+import cats.syntax.all.*
+
+import io.renku.search.GeneratorSyntax.*
+import io.renku.search.model.Id
+import io.renku.search.model.projects.MemberRole
+import io.renku.search.model.projects.Visibility
+import io.renku.search.query.Query
+import io.renku.search.solr.client.SolrDocumentGenerators
+import io.renku.search.solr.documents.*
+import org.scalacheck.Gen
+import org.scalacheck.cats.implicits.*
+
+final case class AuthTestData(
+    user1: User,
+    user2: User,
+    user3: User,
+    projects: Map[AuthTestData.UserProjectKey, Project]
+):
+  val users = List(user1, user2, user3)
+  val all: List[EntityDocument] = users ++ projects.values.toList
+  val user1PublicProject: Project = projects(user1.id -> Visibility.Public)
+  val user2PublicProject: Project = projects(user2.id -> Visibility.Public)
+  val user3PublicProject: Project = projects(user3.id -> Visibility.Public)
+  val user1PrivateProject: Project = projects(user1.id -> Visibility.Private)
+  val user2PrivateProject: Project = projects(user2.id -> Visibility.Private)
+  val user3PrivateProject: Project = projects(user3.id -> Visibility.Private)
+
+  def modifyProject(key: AuthTestData.UserProjectKey)(
+      f: Project => Project
+  ): AuthTestData =
+    val p = f(projects(key))
+    copy(projects = projects.updated(key, p))
+
+  def queryAll =
+    Query(Query.Segment.projectIdIs(all.head.id.value, all.tail.map(_.id.value): _*))
+
+  def user1EntityIds =
+    users.map(_.id) ++ List(
+      user1PublicProject,
+      user1PrivateProject,
+      user2PublicProject,
+      user2PrivateProject,
+      user3PublicProject
+    ).map(_.id)
+
+  def user2EntityIds =
+    users.map(_.id) ++ List(
+      user1PublicProject,
+      user2PublicProject,
+      user2PrivateProject,
+      user3PublicProject,
+      user3PrivateProject
+    ).map(_.id)
+
+  def user3EntityIds =
+    users.map(_.id) ++ List(
+      user1PublicProject,
+      user2PublicProject,
+      user3PublicProject,
+      user3PrivateProject
+    ).map(_.id)
+
+  def publicEntityIds =
+    users.map(_.id) ++ List(
+      user1PublicProject,
+      user2PublicProject,
+      user3PublicProject
+    ).map(_.id)
+
+  private def setupRelations =
+    // user1 is member of user2 private project
+    modifyProject(user2.id -> Visibility.Private)(
+      _.addMember(user1.id, MemberRole.Member)
+    )
+      // user2 is owner of user3 private project
+      .modifyProject(user3.id -> Visibility.Private)(
+        _.addMember(user2.id, MemberRole.Owner)
+      )
+
+object AuthTestData:
+  private type UserProjectKey = (Id, Visibility)
+  private def projectGen(user: User, vis: Visibility) =
+    SolrDocumentGenerators
+      .projectDocumentGen(
+        s"user${user.id}-${vis.name}-proj",
+        "description",
+        Gen.const(vis)
+      )
+      .map(p => (user.id, vis) -> p.copy(owners = List(user.id)))
+
+  val generator: Gen[AuthTestData] = for {
+    u1 <- SolrDocumentGenerators.userDocumentGen
+    u2 <- SolrDocumentGenerators.userDocumentGen
+    u3 <- SolrDocumentGenerators.userDocumentGen
+    projects <- Visibility.values.toList
+      .flatMap(v => List(u1, u2, u3).map(_ -> v))
+      .traverse { case (user, vis) =>
+        projectGen(user, vis)
+      }
+  } yield AuthTestData(u1, u2, u3, projects.toMap).setupRelations
+
+  def generate: IO[AuthTestData] = IO(generator.generateOne)

--- a/modules/search-solr-client/src/test/scala/io/renku/search/solr/query/AuthTestData.scala
+++ b/modules/search-solr-client/src/test/scala/io/renku/search/solr/query/AuthTestData.scala
@@ -53,7 +53,7 @@ final case class AuthTestData(
     copy(projects = projects.updated(key, p))
 
   def queryAll =
-    Query(Query.Segment.projectIdIs(all.head.id.value, all.tail.map(_.id.value): _*))
+    Query(Query.Segment.idIs(all.head.id.value, all.tail.map(_.id.value): _*))
 
   def user1EntityIds =
     users.map(_.id) ++ List(

--- a/modules/search-solr-client/src/test/scala/io/renku/search/solr/query/SolrTokenSpec.scala
+++ b/modules/search-solr-client/src/test/scala/io/renku/search/solr/query/SolrTokenSpec.scala
@@ -28,14 +28,14 @@ class SolrTokenSpec extends FunSuite:
     assertEquals(
       List(
         SolrToken.fieldIs(Field.Name, SolrToken.fromString("john")),
-        SolrToken.fieldIs(Field.ProjectId, SolrToken.fromString("1"))
+        SolrToken.fieldIs(Field.Id, SolrToken.fromString("1"))
       ).foldAnd,
       SolrToken.unsafeFromString("(name:john AND id:1)")
     )
     assertEquals(
       List(
         SolrToken.fieldIs(Field.Name, SolrToken.fromString("john")),
-        SolrToken.fieldIs(Field.ProjectId, SolrToken.fromString("1"))
+        SolrToken.fieldIs(Field.Id, SolrToken.fromString("1"))
       ).foldOr,
       SolrToken.unsafeFromString("(name:john OR id:1)")
     )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,7 +23,12 @@ object Dependencies {
     val scribe = "3.13.0"
     val sttpApiSpec = "0.7.4"
     val tapir = "1.9.11"
+    val jwtScala = "10.0.0";
   }
+
+  val jwtScala = Seq(
+    "com.github.jwt-scala" %% "jwt-core" % V.jwtScala
+  )
 
   val catsScalaCheck = Seq(
     "io.chrisdavenport" %% "cats-scalacheck" % V.catsScalaCheck


### PR DESCRIPTION
- Uses information from the request to amend the search query such that visibility of projects is honored
- public projects (and users, that have a public visibility by default) are always included
- private projects are only included, if the calling subject is owner or member
- Rename field `projectId` to `id` for the user defined query. The id can select any entity type