### PR TITLE
feat: partial entity documents

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -76,6 +76,8 @@
             RS_REDIS_PORT = "6379";
             RS_CONTAINER = "rsdev";
             RS_LOG_LEVEL = "3";
+            RS_SEARCH_HTTP_SERVER_PORT = "8080";
+            RS_PROVISION_HTTP_SERVER_PORT = "8082";
 
             #don't start docker container for dbTests
             NO_SOLR = "true";
@@ -96,6 +98,8 @@
             RS_REDIS_PORT = "16379";
             VM_SSH_PORT = "10022";
             RS_LOG_LEVEL = "3";
+            RS_SEARCH_HTTP_SERVER_PORT = "8080";
+            RS_PROVISION_HTTP_SERVER_PORT = "8082";
 
             #don't start docker container for dbTests
             NO_SOLR = "true";

--- a/modules/config-values/src/main/scala/io/renku/search/config/ConfigValues.scala
+++ b/modules/config-values/src/main/scala/io/renku/search/config/ConfigValues.scala
@@ -78,7 +78,7 @@ object ConfigValues extends ConfigDecoders:
     (url, core, maybeUser, defaultCommit, logMessageBodies).mapN(SolrConfig.apply)
   }
 
-  def httpServerConfig(defaultPort: Port): ConfigValue[Effect, HttpServerConfig] =
-    val bindAddress = renv("HTTP_SERVER_BIND_ADDRESS").default("0.0.0.0").as[Ipv4Address]
-    val port = renv("HTTP_SERVER_PORT").default(defaultPort.value.toString).as[Port]
+  def httpServerConfig(prefix: String, defaultPort: Port): ConfigValue[Effect, HttpServerConfig] =
+    val bindAddress = renv(s"${prefix}_HTTP_SERVER_BIND_ADDRESS").default("0.0.0.0").as[Ipv4Address]
+    val port = renv(s"${prefix}_HTTP_SERVER_PORT").default(defaultPort.value.toString).as[Port]
     (bindAddress, port).mapN(HttpServerConfig.apply)

--- a/modules/search-api/src/main/scala/io/renku/search/api/SearchApiConfig.scala
+++ b/modules/search-api/src/main/scala/io/renku/search/api/SearchApiConfig.scala
@@ -35,6 +35,6 @@ object SearchApiConfig:
   val config: ConfigValue[Effect, SearchApiConfig] =
     (
       ConfigValues.solrConfig,
-      ConfigValues.httpServerConfig(port"8080"),
+      ConfigValues.httpServerConfig("SEARCH", port"8080"),
       ConfigValues.logLevel
     ).mapN(SearchApiConfig.apply)

--- a/modules/search-provision/src/main/scala/io/renku/search/provision/SearchProvisionConfig.scala
+++ b/modules/search-provision/src/main/scala/io/renku/search/provision/SearchProvisionConfig.scala
@@ -49,6 +49,6 @@ object SearchProvisionConfig:
       ConfigValues.metricsUpdateInterval,
       ConfigValues.logLevel,
       QueuesConfig.config,
-      ConfigValues.httpServerConfig(defaultPort = port"8081"),
+      ConfigValues.httpServerConfig("PROVISION", defaultPort = port"8081"),
       ConfigValues.clientId(ClientId("search-provisioner"))
     ).mapN(SearchProvisionConfig.apply)

--- a/modules/search-provision/src/main/scala/io/renku/search/provision/handler/FetchFromSolr.scala
+++ b/modules/search-provision/src/main/scala/io/renku/search/provision/handler/FetchFromSolr.scala
@@ -22,20 +22,20 @@ import cats.effect.Sync
 import cats.syntax.all.*
 import fs2.{Pipe, Stream}
 
+import io.bullet.borer.Decoder
+import io.bullet.borer.derivation.MapBasedCodecs
+import io.renku.search.model.EntityType
 import io.renku.search.model.Id
 import io.renku.search.provision.handler.FetchFromSolr.MessageDocument
 import io.renku.search.provision.handler.MessageReader.Message
+import io.renku.search.query.Query
+import io.renku.search.solr.SearchRole
 import io.renku.search.solr.client.SearchSolrClient
 import io.renku.search.solr.documents.EntityDocument
-import io.renku.search.query.Query
-import io.bullet.borer.derivation.MapBasedCodecs
-import io.bullet.borer.Decoder
-import io.renku.search.solr.SearchRole
-import io.renku.search.solr.schema.EntityDocumentSchema.Fields
-import io.renku.solr.client.QueryString
-import io.renku.solr.client.QueryData
 import io.renku.search.solr.query.SolrToken
-import io.renku.search.model.EntityType
+import io.renku.search.solr.schema.EntityDocumentSchema.Fields
+import io.renku.solr.client.QueryData
+import io.renku.solr.client.QueryString
 
 trait FetchFromSolr[F[_]]:
   def fetch1[A](using IdExtractor[A]): Pipe[F, Message[A], MessageDocument[A]]
@@ -76,10 +76,7 @@ object FetchFromSolr:
       def fetchProjectForUser(userId: Id): Stream[F, FetchFromSolr.ProjectId] =
         val query = QueryString(
           List(
-            SolrToken.fieldIs(
-              Fields.entityType,
-              SolrToken.fromEntityType(EntityType.Project)
-            ),
+            SolrToken.entityTypeIs(EntityType.Project),
             List(
               SolrToken.fieldIs(Fields.owners, SolrToken.fromId(userId)),
               SolrToken.fieldIs(Fields.members, SolrToken.fromId(userId))

--- a/modules/search-provision/src/main/scala/io/renku/search/provision/handler/FetchFromSolr.scala
+++ b/modules/search-provision/src/main/scala/io/renku/search/provision/handler/FetchFromSolr.scala
@@ -33,7 +33,6 @@ import io.renku.search.solr.SearchRole
 import io.renku.search.solr.client.SearchSolrClient
 import io.renku.search.solr.documents.EntityDocument
 import io.renku.search.solr.query.SolrToken
-import io.renku.search.solr.schema.EntityDocumentSchema.Fields
 import io.renku.solr.client.QueryData
 import io.renku.solr.client.QueryString
 
@@ -78,8 +77,8 @@ object FetchFromSolr:
           List(
             SolrToken.entityTypeIs(EntityType.Project),
             List(
-              SolrToken.fieldIs(Fields.owners, SolrToken.fromId(userId)),
-              SolrToken.fieldIs(Fields.members, SolrToken.fromId(userId))
+              SolrToken.ownerIs(userId),
+              SolrToken.memberIs(userId)
             ).foldOr
           ).foldAnd.value
         )

--- a/modules/search-provision/src/test/scala/io/renku/search/provision/project/AuthorizationAddedProvisioningSpec.scala
+++ b/modules/search-provision/src/test/scala/io/renku/search/provision/project/AuthorizationAddedProvisioningSpec.scala
@@ -32,7 +32,7 @@ import io.renku.queue.client.Generators.messageHeaderGen
 import io.renku.search.GeneratorSyntax.*
 import io.renku.search.model.{Id, projects}
 import io.renku.search.provision.ProvisioningSuite
-import io.renku.search.solr.documents.{EntityDocument, Project}
+import io.renku.search.solr.documents.{CompoundId, EntityDocument, Project}
 import munit.CatsEffectSuite
 
 class AuthorizationAddedProvisioningSpec extends ProvisioningSuite:
@@ -63,7 +63,11 @@ class AuthorizationAddedProvisioningSpec extends ProvisioningSuite:
                 .evalTap(_ =>
                   scribe.cats.io.info(s"Looking for project with id ${projectDoc.id}...")
                 )
-                .evalMap(_ => solrClient.findById[EntityDocument](projectDoc.id))
+                .evalMap(_ =>
+                  solrClient.findById[EntityDocument](
+                    CompoundId.projectEntity(projectDoc.id)
+                  )
+                )
                 .evalMap(
                   _.fold(().pure[IO])(e =>
                     solrDocs.update(_ => Set(e.asInstanceOf[Project]))

--- a/modules/search-provision/src/test/scala/io/renku/search/provision/project/ProjectUpdatedProvisioningSpec.scala
+++ b/modules/search-provision/src/test/scala/io/renku/search/provision/project/ProjectUpdatedProvisioningSpec.scala
@@ -19,10 +19,12 @@
 package io.renku.search.provision.project
 
 import scala.concurrent.duration.*
+
 import cats.effect.{IO, Resource}
 import cats.syntax.all.*
 import fs2.Stream
 import fs2.concurrent.SignallingRef
+
 import io.github.arainko.ducktape.*
 import io.renku.avro.codec.encoders.all.given
 import io.renku.events.EventsGenerators.*
@@ -31,7 +33,7 @@ import io.renku.queue.client.Generators.messageHeaderGen
 import io.renku.search.GeneratorSyntax.*
 import io.renku.search.model.Id
 import io.renku.search.provision.ProvisioningSuite
-import io.renku.search.solr.documents.{EntityDocument, Project}
+import io.renku.search.solr.documents.{CompoundId, EntityDocument}
 import munit.CatsEffectSuite
 
 class ProjectUpdatedProvisioningSpec extends ProvisioningSuite:
@@ -58,7 +60,11 @@ class ProjectUpdatedProvisioningSpec extends ProvisioningSuite:
             docsCollectorFiber <-
               Stream
                 .awakeEvery[IO](500 millis)
-                .evalMap(_ => solrClient.findById[Project](Id(created.id)))
+                .evalMap(_ =>
+                  solrClient.findById[EntityDocument](
+                    CompoundId.projectEntity(Id(created.id))
+                  )
+                )
                 .evalMap(_.fold(().pure[IO])(e => solrDocs.update(_ => Set(e))))
                 .compile
                 .drain

--- a/modules/search-provision/src/test/scala/io/renku/search/provision/user/UserAddedProvisioningSpec.scala
+++ b/modules/search-provision/src/test/scala/io/renku/search/provision/user/UserAddedProvisioningSpec.scala
@@ -18,20 +18,21 @@
 
 package io.renku.search.provision.user
 
+import scala.concurrent.duration.*
+
 import cats.effect.{IO, Resource}
 import fs2.Stream
 import fs2.concurrent.SignallingRef
+
 import io.renku.avro.codec.encoders.all.given
 import io.renku.events.EventsGenerators.userAddedGen
 import io.renku.events.v1.UserAdded
 import io.renku.queue.client.Generators.messageHeaderGen
 import io.renku.search.GeneratorSyntax.*
 import io.renku.search.model.Id
-import io.renku.search.solr.documents.{EntityDocument, User}
-import munit.CatsEffectSuite
-
-import scala.concurrent.duration.*
 import io.renku.search.provision.ProvisioningSuite
+import io.renku.search.solr.documents.{CompoundId, EntityDocument}
+import munit.CatsEffectSuite
 
 class UserAddedProvisioningSpec extends ProvisioningSuite:
 
@@ -52,7 +53,9 @@ class UserAddedProvisioningSpec extends ProvisioningSuite:
         docsCollectorFiber <-
           Stream
             .awakeEvery[IO](500 millis)
-            .evalMap(_ => solrClient.findById[User](Id(userAdded.id)))
+            .evalMap(_ =>
+              solrClient.findById[EntityDocument](CompoundId.userEntity(Id(userAdded.id)))
+            )
             .evalMap(e => solrDoc.update(_ => e))
             .compile
             .drain

--- a/modules/search-query-docs/docs/manual.md
+++ b/modules/search-query-docs/docs/manual.md
@@ -43,7 +43,7 @@ _either_ `public` _or_ `private`.
 The following fields are available:
 
 ```scala mdoc:passthrough
-import io.renku.search.model.EntityType
+import io.renku.search.model.*
 import io.renku.search.query.*
 println(Field.values.map(e => s"`${e.name}`").mkString("- ", "\n- ", ""))
 ```
@@ -67,6 +67,31 @@ Example:
 ```scala mdoc:passthrough
 println(s" `${Field.Type.name}:${EntityType.Project.name}`")
 ```
+
+### Roles
+
+The field `role` allows to search for projects the current user has
+the given role. Other entities are excluded from the results.
+
+```scala mdoc:passthrough
+println(
+  projects.MemberRole.values.map(e => s"`${e.name}`").mkString("- ", "\n- ", "")
+)
+```
+
+### Visibility
+
+The `visibility` field can be used to restrict to entities with a
+certain visibility. Users have a default visibility of `public`.
+Possbile values are:
+
+```scala mdoc:passthrough
+println(
+  projects.Visibility.values.map(e => s"`${e.name}`").mkString("- ", "\n- ", "")
+)
+```
+
+
 
 ### Dates
 

--- a/modules/search-solr-client/src/main/scala/io/renku/search/solr/client/SearchSolrClient.scala
+++ b/modules/search-solr-client/src/main/scala/io/renku/search/solr/client/SearchSolrClient.scala
@@ -18,8 +18,6 @@
 
 package io.renku.search.solr.client
 
-import scala.reflect.ClassTag
-
 import cats.data.NonEmptyList
 import cats.effect.{Async, Resource}
 import fs2.Stream
@@ -29,11 +27,11 @@ import io.bullet.borer.{Decoder, Encoder}
 import io.renku.search.model.Id
 import io.renku.search.query.Query
 import io.renku.search.solr.SearchRole
-import io.renku.search.solr.documents.EntityDocument
+import io.renku.search.solr.documents.*
 import io.renku.solr.client.*
 
 trait SearchSolrClient[F[_]]:
-  def findById[D <: EntityDocument](id: Id)(using ct: ClassTag[D]): F[Option[D]]
+  def findById[D: Decoder](id: CompoundId): F[Option[D]]
   def insert[D: Encoder](documents: Seq[D]): F[Unit]
   def deleteIds(ids: NonEmptyList[Id]): F[Unit]
   def query[D: Decoder](query: QueryData): F[QueryResponse[D]]

--- a/modules/search-solr-client/src/main/scala/io/renku/search/solr/documents/CompoundId.scala
+++ b/modules/search-solr-client/src/main/scala/io/renku/search/solr/documents/CompoundId.scala
@@ -23,7 +23,6 @@ import cats.syntax.all.*
 import io.renku.search.model.EntityType
 import io.renku.search.model.Id
 import io.renku.search.solr.query.SolrToken
-import io.renku.search.solr.schema.EntityDocumentSchema.Fields
 import io.renku.solr.client.{QueryData, QueryString}
 
 final case class CompoundId(
@@ -33,7 +32,7 @@ final case class CompoundId(
 ):
   private[solr] def toQuery: SolrToken =
     List(
-      SolrToken.fieldIs(Fields.id, SolrToken.fromId(id)),
+      SolrToken.idIs(id),
       SolrToken.kindIs(kind),
       entityType.map(SolrToken.entityTypeIs).getOrElse(SolrToken.empty)
     ).foldAnd
@@ -43,10 +42,10 @@ final case class CompoundId(
 
 object CompoundId:
   def partial(id: Id, entityType: Option[EntityType] = None): CompoundId =
-    CompoundId(id, DocumentKind.Partial, entityType)
+    CompoundId(id, DocumentKind.PartialEntity, entityType)
 
   def entity(id: Id, entityType: Option[EntityType] = None): CompoundId =
-    CompoundId(id, DocumentKind.Entity, entityType)
+    CompoundId(id, DocumentKind.FullEntity, entityType)
 
   def projectEntity(id: Id): CompoundId = entity(id, EntityType.Project.some)
   def userEntity(id: Id): CompoundId = entity(id, EntityType.User.some)

--- a/modules/search-solr-client/src/main/scala/io/renku/search/solr/documents/CompoundId.scala
+++ b/modules/search-solr-client/src/main/scala/io/renku/search/solr/documents/CompoundId.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.search.solr.documents
+
+import cats.syntax.all.*
+
+import io.renku.search.model.EntityType
+import io.renku.search.model.Id
+import io.renku.search.solr.query.SolrToken
+import io.renku.search.solr.schema.EntityDocumentSchema.Fields
+import io.renku.solr.client.{QueryData, QueryString}
+
+final case class CompoundId(
+    id: Id,
+    kind: DocumentKind,
+    entityType: Option[EntityType] = None
+):
+  private[solr] def toQuery: SolrToken =
+    List(
+      SolrToken.fieldIs(Fields.id, SolrToken.fromId(id)),
+      SolrToken.kindIs(kind),
+      entityType.map(SolrToken.entityTypeIs).getOrElse(SolrToken.empty)
+    ).foldAnd
+
+  private[solr] def toQueryData: QueryData =
+    QueryData(QueryString(toQuery.value, 1, 0))
+
+object CompoundId:
+  def partial(id: Id, entityType: Option[EntityType] = None): CompoundId =
+    CompoundId(id, DocumentKind.Partial, entityType)
+
+  def entity(id: Id, entityType: Option[EntityType] = None): CompoundId =
+    CompoundId(id, DocumentKind.Entity, entityType)
+
+  def projectEntity(id: Id): CompoundId = entity(id, EntityType.Project.some)
+  def userEntity(id: Id): CompoundId = entity(id, EntityType.User.some)
+
+  def projectPartial(id: Id): CompoundId = partial(id, EntityType.Project.some)

--- a/modules/search-solr-client/src/main/scala/io/renku/search/solr/documents/DocumentKind.scala
+++ b/modules/search-solr-client/src/main/scala/io/renku/search/solr/documents/DocumentKind.scala
@@ -24,8 +24,8 @@ import io.renku.search.solr.schema.EntityDocumentSchema.Fields
 import io.renku.solr.client.EncoderSupport
 
 enum DocumentKind:
-  case Entity
-  case Partial
+  case FullEntity
+  case PartialEntity
 
   val name: String = productPrefix.toLowerCase
 

--- a/modules/search-solr-client/src/main/scala/io/renku/search/solr/documents/DocumentKind.scala
+++ b/modules/search-solr-client/src/main/scala/io/renku/search/solr/documents/DocumentKind.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.search.solr.documents
+
+import io.bullet.borer.Decoder
+import io.bullet.borer.Encoder
+import io.renku.search.solr.schema.EntityDocumentSchema.Fields
+import io.renku.solr.client.EncoderSupport
+
+enum DocumentKind:
+  case Entity
+  case Partial
+
+  val name: String = productPrefix.toLowerCase
+
+  private[documents] def additionalField[A]: EncoderSupport.AdditionalFields[A, String] =
+    EncoderSupport.AdditionalFields.const[A, String](Fields.kind.name -> name)
+
+object DocumentKind:
+  given Encoder[DocumentKind] = Encoder.forString.contramap(_.name)
+  given Decoder[DocumentKind] = Decoder.forString.mapEither(fromString)
+
+  def fromString(s: String): Either[String, DocumentKind] =
+    DocumentKind.values
+      .find(_.name.equalsIgnoreCase(s))
+      .toRight(s"Invalid document kind: $s")
+
+  def unsafeFromString(s: String): DocumentKind =
+    fromString(s).fold(sys.error, identity)

--- a/modules/search-solr-client/src/main/scala/io/renku/search/solr/documents/EntityDocument.scala
+++ b/modules/search-solr-client/src/main/scala/io/renku/search/solr/documents/EntityDocument.scala
@@ -18,30 +18,26 @@
 
 package io.renku.search.solr.documents
 
+import io.bullet.borer.NullOptions.given
 import io.bullet.borer.*
-import io.bullet.borer.derivation.MapBasedCodecs.*
+import io.bullet.borer.derivation.MapBasedCodecs
 import io.renku.search.model.*
 import io.renku.search.model.projects.MemberRole
 import io.renku.search.model.projects.MemberRole.{Member, Owner}
-import io.renku.solr.client.EncoderSupport.*
 import io.renku.search.model.projects.Visibility
 import io.renku.search.solr.schema.EntityDocumentSchema.Fields
 import io.renku.solr.client.EncoderSupport
 
-sealed trait EntityDocument:
+sealed trait EntityDocument extends SolrDocument:
   val score: Option[Double]
-  val id: Id
   def widen: EntityDocument = this
 
 object EntityDocument:
-
-  val allTypes: Set[String] = Set(Project.entityType, User.entityType)
-
   given AdtEncodingStrategy =
-    AdtEncodingStrategy.flat(typeMemberName = discriminatorField)
+    AdtEncodingStrategy.flat(typeMemberName = Fields.entityType.name)
 
-  given Encoder[EntityDocument] = deriveAllEncoders[EntityDocument]
-  given Decoder[EntityDocument] = deriveAllDecoders[EntityDocument]
+  given Encoder[EntityDocument] = EncoderSupport.derive[EntityDocument]
+  given Decoder[EntityDocument] = MapBasedCodecs.deriveAllDecoders[EntityDocument]
   given Codec[EntityDocument] = Codec.of[EntityDocument]
 
 final case class Project(
@@ -57,7 +53,6 @@ final case class Project(
     members: List[Id] = List.empty,
     score: Option[Double] = None
 ) extends EntityDocument:
-
   def addMember(userId: Id, role: MemberRole): Project =
     role match {
       case Owner  => copy(owners = (userId :: owners).distinct, score = None)
@@ -72,7 +67,11 @@ final case class Project(
     )
 
 object Project:
-  val entityType: String = "Project"
+  given Encoder[Project] =
+    EncoderSupport.deriveWith(
+      DocumentKind.Entity.additionalField,
+      EncoderSupport.AdditionalFields.productPrefix(Fields.entityType.name)
+    )
 
 final case class User(
     id: Id,
@@ -83,10 +82,14 @@ final case class User(
 ) extends EntityDocument
 
 object User:
-  val entityType: String = "User"
-  // auto-add a visibility:public to users
   given Encoder[User] =
-    EncoderSupport.deriveWithAdditional(Fields.visibility.name, Visibility.Public)
+    EncoderSupport.deriveWith(
+      DocumentKind.Entity.additionalField,
+      EncoderSupport.AdditionalFields.productPrefix(Fields.entityType.name),
+      EncoderSupport.AdditionalFields.const[User, String](
+        Fields.visibility.name -> Visibility.Public.name
+      )
+    )
 
   def nameFrom(firstName: Option[String], lastName: Option[String]): Option[Name] =
     Option(List(firstName, lastName).flatten.mkString(" "))

--- a/modules/search-solr-client/src/main/scala/io/renku/search/solr/documents/EntityDocument.scala
+++ b/modules/search-solr-client/src/main/scala/io/renku/search/solr/documents/EntityDocument.scala
@@ -69,7 +69,7 @@ final case class Project(
 object Project:
   given Encoder[Project] =
     EncoderSupport.deriveWith(
-      DocumentKind.Entity.additionalField,
+      DocumentKind.FullEntity.additionalField,
       EncoderSupport.AdditionalFields.productPrefix(Fields.entityType.name)
     )
 
@@ -84,7 +84,7 @@ final case class User(
 object User:
   given Encoder[User] =
     EncoderSupport.deriveWith(
-      DocumentKind.Entity.additionalField,
+      DocumentKind.FullEntity.additionalField,
       EncoderSupport.AdditionalFields.productPrefix(Fields.entityType.name),
       EncoderSupport.AdditionalFields.const[User, String](
         Fields.visibility.name -> Visibility.Public.name

--- a/modules/search-solr-client/src/main/scala/io/renku/search/solr/documents/PartialEntityDocument.scala
+++ b/modules/search-solr-client/src/main/scala/io/renku/search/solr/documents/PartialEntityDocument.scala
@@ -61,6 +61,6 @@ object PartialEntityDocument:
   object Project:
     given Encoder[Project] =
       EncoderSupport.deriveWith(
-        DocumentKind.Partial.additionalField,
+        DocumentKind.PartialEntity.additionalField,
         EncoderSupport.AdditionalFields.productPrefix(SolrField.entityType.name)
       )

--- a/modules/search-solr-client/src/main/scala/io/renku/search/solr/documents/PartialEntityDocument.scala
+++ b/modules/search-solr-client/src/main/scala/io/renku/search/solr/documents/PartialEntityDocument.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.search.solr.documents
+
+import io.bullet.borer.*
+import io.bullet.borer.derivation.MapBasedCodecs
+import io.renku.search.model.Id
+import io.renku.search.model.projects.*
+import io.renku.search.solr.documents.Project as ProjectDocument
+import io.renku.search.solr.schema.EntityDocumentSchema.Fields as SolrField
+import io.renku.solr.client.EncoderSupport
+
+sealed trait PartialEntityDocument extends SolrDocument:
+  def applyTo(e: EntityDocument): EntityDocument
+
+object PartialEntityDocument:
+  given AdtEncodingStrategy =
+    AdtEncodingStrategy.flat(typeMemberName = SolrField.entityType.name)
+
+  given Encoder[PartialEntityDocument] = EncoderSupport.derive[PartialEntityDocument]
+  given Decoder[PartialEntityDocument] =
+    MapBasedCodecs.deriveAllDecoders[PartialEntityDocument]
+  given Codec[PartialEntityDocument] = Codec.of[PartialEntityDocument]
+
+  // we must name it the same as the "full" entity documents so that borer
+  // generates the same discriminator (it is not configurable)
+  final case class Project(
+      id: Id,
+      owners: List[Id] = List.empty,
+      members: List[Id] = List.empty
+  ) extends PartialEntityDocument:
+    def applyTo(e: EntityDocument): EntityDocument =
+      e match
+        case p: ProjectDocument => applyTo(p)
+        case _                  => e
+
+    def applyTo(p: Project): Project =
+      if (p.id == id)
+        p.copy(
+          members = (p.members ++ members).distinct,
+          owners = (p.owners ++ owners).distinct
+        )
+      else p
+
+  object Project:
+    given Encoder[Project] =
+      EncoderSupport.deriveWith(
+        DocumentKind.Partial.additionalField,
+        EncoderSupport.AdditionalFields.productPrefix(SolrField.entityType.name)
+      )

--- a/modules/search-solr-client/src/main/scala/io/renku/search/solr/documents/SolrDocument.scala
+++ b/modules/search-solr-client/src/main/scala/io/renku/search/solr/documents/SolrDocument.scala
@@ -16,25 +16,9 @@
  * limitations under the License.
  */
 
-package io.renku.solr.client
+package io.renku.search.solr.documents
 
-import io.bullet.borer._
-import io.bullet.borer.derivation.MapBasedCodecs.deriveDecoder
-import io.renku.solr.client.JsonEncodingSpec.Room
-import munit.FunSuite
+import io.renku.search.model.Id
 
-class JsonEncodingSpec extends FunSuite {
-
-  test("test with discriminator"):
-    val r = Room("meeting room", 59)
-    val json = Json.encode(r).toUtf8String
-    val rr = Json.decode(json.getBytes).to[Room].value
-    assertEquals(json, """{"_type":"Room","name":"meeting room","seats":59}""")
-    assertEquals(rr, r)
-}
-
-object JsonEncodingSpec:
-  case class Room(name: String, seats: Int)
-  object Room:
-    given Decoder[Room] = deriveDecoder
-    given Encoder[Room] = EncoderSupport.deriveWithDiscriminator[Room]("_type")
+trait SolrDocument:
+  def id: Id

--- a/modules/search-solr-client/src/main/scala/io/renku/search/solr/query/LuceneQueryInterpreter.scala
+++ b/modules/search-solr-client/src/main/scala/io/renku/search/solr/query/LuceneQueryInterpreter.scala
@@ -34,17 +34,14 @@ final class LuceneQueryInterpreter[F[_]: Monad]
   private val encoder = SolrTokenEncoder[F, Query]
 
   def run(ctx: Context[F], query: Query): F[SolrQuery] =
-    amendUserId(ctx.role) {
-      if (query.isEmpty) SolrQuery(SolrToken.allTypes).pure[F]
-      else encoder.encode(ctx, query)
-    }
+    amendQuery(ctx.role)(encoder.encode(ctx, query))
 
-  private def amendUserId(role: SearchRole)(sq: F[SolrQuery]): F[SolrQuery] =
+  private def amendQuery(role: SearchRole)(sq: F[SolrQuery]): F[SolrQuery] =
     sq.map { query =>
       role match
         case SearchRole.Anonymous => query.asAnonymous
         case SearchRole.User(id)  => query.asUser(id)
-        case SearchRole.Admin     => query
+        case SearchRole.Admin     => query.asAdmin
     }
 
 object LuceneQueryInterpreter:

--- a/modules/search-solr-client/src/main/scala/io/renku/search/solr/query/SolrQuery.scala
+++ b/modules/search-solr-client/src/main/scala/io/renku/search/solr/query/SolrQuery.scala
@@ -39,7 +39,7 @@ final case class SolrQuery(
       List(
         query.parens,
         SolrToken.publicOnly,
-        SolrToken.kindIs(DocumentKind.Entity)
+        SolrToken.kindIs(DocumentKind.FullEntity)
       ).foldAnd,
       sort
     )
@@ -49,13 +49,13 @@ final case class SolrQuery(
       List(
         query.parens,
         SolrToken.forUser(id),
-        SolrToken.kindIs(DocumentKind.Entity)
+        SolrToken.kindIs(DocumentKind.FullEntity)
       ).foldAnd,
       sort
     )
 
   def asAdmin: SolrQuery =
-    SolrQuery(List(query, SolrToken.kindIs(DocumentKind.Entity)).foldAnd, sort)
+    SolrQuery(List(query, SolrToken.kindIs(DocumentKind.FullEntity)).foldAnd, sort)
 
 object SolrQuery:
   val empty: SolrQuery = SolrQuery(SolrToken.empty, SolrSort.empty)

--- a/modules/search-solr-client/src/main/scala/io/renku/search/solr/query/SolrToken.scala
+++ b/modules/search-solr-client/src/main/scala/io/renku/search/solr/query/SolrToken.scala
@@ -41,6 +41,8 @@ object SolrToken:
   def fromVisibility(v: Visibility): SolrToken = v.name
   private def fromEntityType(et: EntityType): SolrToken = et.name
 
+  def idIs(id: Id): SolrToken = fieldIs(SolrField.id, fromId(id))
+
   def entityTypeIs(et: EntityType): SolrToken =
     fieldIs(SolrField.entityType, fromEntityType(et))
 
@@ -73,17 +75,17 @@ object SolrToken:
     fieldIs(SolrField.creationDate, s"[* TO ${fromInstant(date)}]")
 
   lazy val allEntityTypes: SolrToken =
-    List(fieldIs(SolrField.entityType, "*"), kindIs(DocumentKind.Entity)).foldAnd
+    List(fieldIs(SolrField.entityType, "*"), kindIs(DocumentKind.FullEntity)).foldAnd
 
   val publicOnly: SolrToken =
     fieldIs(SolrField.visibility, fromVisibility(Visibility.Public))
 
-  def ownerIs(id: Id): SolrToken = SolrField.owners.name === fromId(id)
-  def memberIs(id: Id): SolrToken = SolrField.members.name === fromId(id)
+  def ownerIs(id: Id): SolrToken = fieldIs(SolrField.owners, fromId(id))
+  def memberIs(id: Id): SolrToken = fieldIs(SolrField.members, fromId(id))
 
   def roleIs(id: Id, role: MemberRole): SolrToken = role match
-    case MemberRole.Owner  => fieldIs(SolrField.owners, fromId(id))
-    case MemberRole.Member => fieldIs(SolrField.members, fromId(id))
+    case MemberRole.Owner  => ownerIs(id)
+    case MemberRole.Member => memberIs(id)
 
   def roleIn(id: Id, roles: NonEmptyList[MemberRole]): SolrToken =
     roles.toList.distinct.map(roleIs(id, _)).foldOr

--- a/modules/search-solr-client/src/main/scala/io/renku/search/solr/schema/EntityDocumentSchema.scala
+++ b/modules/search-solr-client/src/main/scala/io/renku/search/solr/schema/EntityDocumentSchema.scala
@@ -27,6 +27,7 @@ object EntityDocumentSchema:
     val creationDate: FieldName = FieldName("creationDate")
     val description: FieldName = FieldName("description")
     val entityType: FieldName = FieldName("_type")
+    val kind: FieldName = FieldName("_kind")
     val firstName: FieldName = FieldName("firstName")
     val id: FieldName = FieldName("id")
     val lastName: FieldName = FieldName("lastName")
@@ -59,6 +60,7 @@ object EntityDocumentSchema:
     SchemaCommand.Add(FieldTypes.text),
     SchemaCommand.Add(FieldTypes.dateTime),
     SchemaCommand.Add(Field(Fields.entityType, FieldTypes.string)),
+    SchemaCommand.Add(Field(Fields.kind, FieldTypes.string)),
     SchemaCommand.Add(Field(Fields.name, FieldTypes.string)),
     SchemaCommand.Add(Field(Fields.slug, FieldTypes.string)),
     SchemaCommand.Add(Field(Fields.repositories, FieldTypes.string).makeMultiValued),

--- a/modules/search-solr-client/src/test/scala/io/renku/search/solr/client/SearchSolrClientSpec.scala
+++ b/modules/search-solr-client/src/test/scala/io/renku/search/solr/client/SearchSolrClientSpec.scala
@@ -28,7 +28,7 @@ import io.renku.search.query.Query
 import io.renku.search.solr.SearchRole
 import io.renku.search.solr.client.SolrDocumentGenerators.*
 import io.renku.search.solr.documents.EntityOps.*
-import io.renku.search.solr.documents.{EntityDocument, Project, User}
+import io.renku.search.solr.documents.*
 import io.renku.search.solr.schema.EntityDocumentSchema.Fields
 import io.renku.solr.client.QueryData
 import munit.CatsEffectSuite
@@ -48,7 +48,7 @@ class SearchSolrClientSpec extends CatsEffectSuite with SearchSolrSpec:
           0
         )
         _ = assert(qr.responseBody.docs.map(_.noneScore) contains project)
-        gr <- client.findById[Project](project.id)
+        gr <- client.findById[EntityDocument](CompoundId.projectEntity(project.id))
         _ = assert(gr contains project)
       } yield ()
     }
@@ -66,7 +66,7 @@ class SearchSolrClientSpec extends CatsEffectSuite with SearchSolrSpec:
           0
         )
         _ = assert(qr.responseBody.docs.map(_.noneScore) contains user)
-        gr <- client.findById[User](user.id)
+        gr <- client.findById[EntityDocument](CompoundId.userEntity(user.id))
         _ = assert(gr contains user)
       } yield ()
     }

--- a/modules/search-solr-client/src/test/scala/io/renku/search/solr/client/SolrDocumentGenerators.scala
+++ b/modules/search-solr-client/src/test/scala/io/renku/search/solr/client/SolrDocumentGenerators.scala
@@ -19,13 +19,14 @@
 package io.renku.search.solr.client
 
 import cats.syntax.all.*
+
 import io.renku.search.GeneratorSyntax.*
-import io.renku.search.model.*
 import io.renku.search.model.ModelGenerators.*
+import io.renku.search.model.*
+import io.renku.search.model.projects.Visibility
 import io.renku.search.solr.documents.*
 import org.scalacheck.Gen
 import org.scalacheck.cats.implicits.*
-import io.renku.search.model.projects.Visibility
 
 object SolrDocumentGenerators extends SolrDocumentGenerators
 
@@ -33,6 +34,10 @@ trait SolrDocumentGenerators:
 
   private def projectIdGen: Gen[Id] =
     Gen.uuid.map(uuid => Id(uuid.toString))
+
+  val partialProjectGen: Gen[PartialEntityDocument.Project] =
+    val ids = Gen.choose(1, 5).flatMap(n => Gen.listOfN(n, idGen))
+    (projectIdGen, ids, ids).mapN(PartialEntityDocument.Project.apply)
 
   val projectDocumentGen: Gen[Project] =
     val differentiator = nameGen.generateOne

--- a/modules/search-solr-client/src/test/scala/io/renku/search/solr/documents/EntityEncodingSpec.scala
+++ b/modules/search-solr-client/src/test/scala/io/renku/search/solr/documents/EntityEncodingSpec.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.search.solr.documents
+
+import io.bullet.borer.Json
+import io.renku.search.GeneratorSyntax.*
+import io.renku.search.solr.client.SolrDocumentGenerators
+import munit.FunSuite
+
+class EntityEncodingSpec extends FunSuite:
+
+  test("full project with kind and type"):
+    val project = SolrDocumentGenerators.projectDocumentGen.generateOne
+    val pJson = Json.encode(project).toUtf8String
+    val user = SolrDocumentGenerators.userDocumentGen.generateOne
+    val uJson = Json.encode(user).toUtf8String
+    val partial = SolrDocumentGenerators.partialProjectGen.generateOne
+    val partialJson = Json.encode(partial).toUtf8String
+    println(pJson)
+    println("---")
+    println(uJson)
+    println("---")
+    println(partialJson)
+
+    val p = Json.decode(pJson.getBytes).to[EntityDocument].value
+    val u = Json.decode(uJson.getBytes).to[EntityDocument].value
+    val x = Json.decode(partialJson.getBytes).to[PartialEntityDocument].value
+    println(s"p: $p")
+    println(s"u: $u")
+    println(s"pp: $x")

--- a/modules/search-solr-client/src/test/scala/io/renku/search/solr/documents/EntityEncodingSpec.scala
+++ b/modules/search-solr-client/src/test/scala/io/renku/search/solr/documents/EntityEncodingSpec.scala
@@ -28,19 +28,30 @@ class EntityEncodingSpec extends FunSuite:
   test("full project with kind and type"):
     val project = SolrDocumentGenerators.projectDocumentGen.generateOne
     val pJson = Json.encode(project).toUtf8String
+    val p = Json.decode(pJson.getBytes).to[EntityDocument].value
+    assert(pJson.contains(""""_kind":"fullentity""""))
+    assert(pJson.contains(""""_type":"Project""""))
+    assertEquals(p, project)
+    val projectADT: EntityDocument = project
+    assertEquals(Json.encode(projectADT).toUtf8String, pJson)
+
+  test("encode partial project with kind and type"):
+    val partial = SolrDocumentGenerators.partialProjectGen.generateOne
+    val pJson = Json.encode(partial).toUtf8String
+    val p = Json.decode(pJson.getBytes).to[PartialEntityDocument].value
+    assert(pJson.contains(""""_kind":"partialentity""""))
+    assert(pJson.contains(""""_type":"Project""""))
+    assertEquals(p, partial)
+    val projectADT: PartialEntityDocument = partial
+    assertEquals(Json.encode(projectADT).toUtf8String, pJson)
+
+  test("encode user with kind, type and visibility"):
     val user = SolrDocumentGenerators.userDocumentGen.generateOne
     val uJson = Json.encode(user).toUtf8String
-    val partial = SolrDocumentGenerators.partialProjectGen.generateOne
-    val partialJson = Json.encode(partial).toUtf8String
-    println(pJson)
-    println("---")
-    println(uJson)
-    println("---")
-    println(partialJson)
-
-    val p = Json.decode(pJson.getBytes).to[EntityDocument].value
     val u = Json.decode(uJson.getBytes).to[EntityDocument].value
-    val x = Json.decode(partialJson.getBytes).to[PartialEntityDocument].value
-    println(s"p: $p")
-    println(s"u: $u")
-    println(s"pp: $x")
+    assert(uJson.contains(""""_kind":"fullentity""""))
+    assert(uJson.contains(""""_type":"User""""))
+    assert(uJson.contains(""""visibility":"public""""))
+    assertEquals(u, user)
+    val userADT: EntityDocument = user
+    assertEquals(Json.encode(userADT).toUtf8String, uJson)

--- a/modules/solr-client/src/main/scala/io/renku/solr/client/EncoderSupport.scala
+++ b/modules/solr-client/src/main/scala/io/renku/solr/client/EncoderSupport.scala
@@ -18,48 +18,112 @@
 
 package io.renku.solr.client
 
-import io.bullet.borer.NullOptions.*
-import io.bullet.borer.{Encoder, Writer}
-
 import scala.compiletime.*
 import scala.deriving.*
 
+import cats.kernel.Monoid
+import cats.syntax.foldable.*
+
+import io.bullet.borer.{Encoder, Writer}
+
+/** Provides encoder derived from product and sum types in the following way:
+  *
+  *   - for product types, it allow to add more fields to the json object using the
+  *     `additionalFields` argument
+  *   - for sum types, it simply selects the encoder in scope for the specific branch;
+  *     i.e. it **does not** add any discriminator - they would need to be included into
+  *     each branch already
+  *
+  * When writing data to solr, it is sometimes useful to amend it with additional
+  * properties that don't need to be decoded, but can be used when querying. Since
+  * decoding is much more difficult, this is left to borers `AdtEncodingStrategy.flat`. It
+  * is then required to add the correct discriminator to each branch of the ADT manually,
+  * together with eventual more properties. Then for the sealed parent, use
+  * `EncoderSupport.derive[ADT]` to select an encoder for each branch.
+  */
 object EncoderSupport {
+  trait AdditionalFields[A, V]:
+    def make(a: A): Map[String, V]
+    def ++(other: AdditionalFields[A, V]): AdditionalFields[A, V] =
+      (a: A) => make(a) ++ other.make(a)
 
-  val discriminatorField: String = "_type"
+  object AdditionalFields:
+    def none[A, V]: AdditionalFields[A, V] = create(_ => Map.empty)
 
-  inline def deriveWithDiscriminator[A <: Product](using
-      Mirror.ProductOf[A]
+    def create[A, V](f: A => Map[String, V]): AdditionalFields[A, V] =
+      (a: A) => f(a)
+
+    def of[A, V](fields: (String, A => V)*): AdditionalFields[A, V] =
+      create(a => fields.toMap.view.mapValues(_.apply(a)).toMap)
+
+    def const[A, V](fields: (String, V)*): AdditionalFields[A, V] =
+      create(_ => fields.toMap)
+
+    def productPrefix[A <: Product](fieldName: String): AdditionalFields[A, String] =
+      create(a => Map(fieldName -> a.productPrefix))
+
+    given [A, V]: Monoid[AdditionalFields[A, V]] =
+      Monoid.instance(none[A, V], _ ++ _)
+
+  inline def derive[A](using Mirror.Of[A]): Encoder[A] =
+    Macros.createEncoder[String, String, A](AdditionalFields.none[A, String])
+
+  inline def deriveWith[A, V: Encoder](
+      additionalFields: AdditionalFields[A, V]*
+  )(using Mirror.Of[A]): Encoder[A] =
+    Macros.createEncoder[String, V, A](additionalFields.combineAll)
+
+  inline def deriveWithDiscriminator[A <: Product](discriminatorField: String)(using
+      Mirror.Of[A]
   ): Encoder[A] =
-    Macros.createEncoder[String, String, A](Map.empty, Some(discriminatorField))
+    val adds = AdditionalFields.of[A, String](discriminatorField -> (_.productPrefix))
+    deriveWith[A, String](adds)
 
-  inline def deriveWithAdditional[V: Encoder, A <: Product](key: String, value: V)(using
-      Mirror.ProductOf[A]
+  inline def deriveWithAdditional[A <: Product, V: Encoder](field: (String, V)*)(using
+      Mirror.Of[A]
   ): Encoder[A] =
-    Macros.createEncoder[String, V, A](Map(key -> value), None)
+    val adds = AdditionalFields.const[A, V](field: _*)
+    Macros.createEncoder[String, V, A](adds)
 
   private object Macros {
 
-    final inline def createEncoder[K: Encoder, V: Encoder, T <: Product](
-        additionalFields: Map[String, V],
-        discriminatorField: Option[K]
-    )(using
-        m: Mirror.ProductOf[T]
-    ): Encoder[T] =
-      val names = summonLabels[m.MirroredElemLabels]
+    final inline def createEncoder[K: Encoder, V: Encoder, T](
+        additionalFields: AdditionalFields[T, V]
+    )(using m: Mirror.Of[T]): Encoder[T] =
       val encoders = summonEncoder[m.MirroredElemTypes]
+      val names = summonLabels[m.MirroredElemLabels]
+      inline m match
+        case s: Mirror.SumOf[T] =>
+          createSumEncoder[K, V, T](s, encoders)
 
+        case p: Mirror.ProductOf[T] =>
+          createProductEncoder[K, V, T](encoders, names, additionalFields)
+
+    private def createProductEncoder[K: Encoder, V: Encoder, T](
+        encoders: List[Encoder[?]],
+        names: List[String],
+        additionalFields: AdditionalFields[T, V]
+    ): Encoder[T] =
       new Encoder[T]:
         def write(w: Writer, value: T): Writer =
-          val kind = value.asInstanceOf[Product].productPrefix
+          val additionalProps = additionalFields.make(value)
           val values = value.asInstanceOf[Product].productIterator.toList
-          w.writeMapOpen(names.size + additionalFields.size + discriminatorField.size)
-          additionalFields.foreach { case (k, v) => w.writeMapMember(k, v) }
-          discriminatorField.foreach(k => w.writeMapMember(k, kind))
+          w.writeMapOpen(names.size + additionalProps.size)
+          additionalProps.foreach { case (k, v) => w.writeMapMember(k, v) }
           names.zip(values).zip(encoders).foreach { case ((k, v), e) =>
             w.writeMapMember(k, v)(Encoder[String], e.asInstanceOf[Encoder[Any]])
           }
           w.writeMapClose()
+
+    private def createSumEncoder[K: Encoder, V: Encoder, T](
+        s: Mirror.SumOf[T],
+        encoders: => List[Encoder[?]]
+    ): Encoder[T] =
+      new Encoder[T] {
+        def write(w: Writer, value: T): Writer =
+          val ord = s.ordinal(value)
+          encoders(ord).asInstanceOf[Encoder[Any]].write(w, value)
+      }
 
     inline def summonEncoder[A <: Tuple]: List[Encoder[_]] =
       inline erasedValue[A] match

--- a/nix/dev-scripts.nix
+++ b/nix/dev-scripts.nix
@@ -44,7 +44,8 @@
   };
 
   solr-recreate-cores = writeShellScriptBin "solr-recreate-cores" ''
-    script=$([ "$(which cnt-solr-recreate-core)" != "" ] && echo "cnt-solr-recreate-core" || echo "vm-solr-recreate-core")
+    set +e
+    script=$([ "$(which cnt-solr-recreate-core 2> /dev/null)" != "" ] && echo "cnt-solr-recreate-core" || echo "vm-solr-recreate-core")
     for c in $@; do
         $script $c
     done


### PR DESCRIPTION
- adds the notion of "partial entity documents", that are necessary to store when we get events in arbitrary order
- configure the http server port per (micro)service

Solr now contains multiple hierarchies of documents. They are differentiated by the `_kind` property. This property separates (possibly) unrelated documents. It will be used to separate "partial entity" and "full entity" documents. Partial entity documents are not ready to be returned in search results and are thus hidden. When completed eventually, they will be moved to a "full entity document". Within each "kind", further distinctions can be made depending on the specific document type. Currently, there are `PartialEntityDocument` and `EntityDocument` separeted by `_kind`. Each has its own ADT hierarchy which will be distnguished by the `_type` member. Since both adt hierarchies are related, they share this `_type` member. I.e. there is a `PartialEntityDocument.Project` which relates to `EntityDocument.Project`, though their structures can be differnt.