### PR TITLE
Remove commitWithin global config option

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -70,7 +70,6 @@
             RS_SOLR_HOST = "rsdev-cnt";
             RS_SOLR_URL = "http://rsdev-cnt:8983/solr";
             RS_SOLR_CORE = "rsdev-test";
-            RS_SOLR_DEFAULT_COMMIT_WITHIN = "1 seconds";
             RS_REDIS_HOST = "rsdev-cnt";
             RS_REDIS_PORT = "6379";
             RS_CONTAINER = "rsdev";
@@ -94,7 +93,6 @@
             RS_SOLR_PORT = "18983";
             RS_SOLR_URL = "http://localhost:18983/solr";
             RS_SOLR_CORE = "rsdev-test";
-            RS_SOLR_DEFAULT_COMMIT_WITHIN = "1 seconds";
             RS_REDIS_HOST = "localhost";
             RS_REDIS_PORT = "16379";
             VM_SSH_PORT = "10022";

--- a/modules/config-values/src/main/scala/io/renku/search/config/ConfigValues.scala
+++ b/modules/config-values/src/main/scala/io/renku/search/config/ConfigValues.scala
@@ -71,14 +71,9 @@ object ConfigValues extends ConfigDecoders:
       (renv("SOLR_USER").default("admin"), renv("SOLR_PASS"))
         .mapN(SolrUser.apply)
         .option
-    val defaultCommit =
-      renv("SOLR_DEFAULT_COMMIT_WITHIN")
-        .default("0 seconds")
-        .as[FiniteDuration]
-        .option
     val logMessageBodies =
       renv("SOLR_LOG_MESSAGE_BODIES").default("false").as[Boolean]
-    (url, core, maybeUser, defaultCommit, logMessageBodies).mapN(SolrConfig.apply)
+    (url, core, maybeUser, logMessageBodies).mapN(SolrConfig.apply)
   }
 
   def httpServerConfig(

--- a/modules/search-query/src/test/scala/io/renku/search/query/QueryGenerators.scala
+++ b/modules/search-query/src/test/scala/io/renku/search/query/QueryGenerators.scala
@@ -93,16 +93,22 @@ object QueryGenerators:
       dir <- sortDirection
     } yield Order.OrderedBy(field, dir)
 
+  private val fieldNames = Field.values.toSet.map(_.name.toLowerCase())
+
   private val alphaNumChars = ('a' to 'z') ++ ('A' to 'Z') ++ ('0' to '9')
   private val simpleWord: Gen[String] = {
     val len = Gen.choose(2, 12)
-    len.flatMap(n => Gen.stringOfN(n, Gen.oneOf(alphaNumChars)))
+    len
+      .flatMap(n => Gen.stringOfN(n, Gen.oneOf(alphaNumChars)))
+      .suchThat(w => !fieldNames.contains(w.toLowerCase()))
   }
 
   private val word: Gen[String] = {
     val chars = alphaNumChars ++ "/{}*?()-:@…_[]^!<>=&#|~`+%\"'".toSeq
     val len = Gen.choose(2, 12)
-    len.flatMap(n => Gen.stringOfN(n, Gen.oneOf(chars)))
+    len
+      .flatMap(n => Gen.stringOfN(n, Gen.oneOf(chars)))
+      .suchThat(w => !fieldNames.contains(w.toLowerCase()))
   }
 
   private val phrase: Gen[String] = {

--- a/modules/solr-client/src/main/scala/io/renku/solr/client/SolrConfig.scala
+++ b/modules/solr-client/src/main/scala/io/renku/solr/client/SolrConfig.scala
@@ -20,13 +20,10 @@ package io.renku.solr.client
 
 import org.http4s.Uri
 
-import scala.concurrent.duration.FiniteDuration
-
 final case class SolrConfig(
     baseUrl: Uri,
     core: String,
     maybeUser: Option[SolrUser],
-    commitWithin: Option[FiniteDuration],
     logMessageBodies: Boolean
 )
 

--- a/modules/solr-client/src/test/scala/io/renku/solr/client/util/SolrServerSuite.scala
+++ b/modules/solr-client/src/test/scala/io/renku/solr/client/util/SolrServerSuite.scala
@@ -23,8 +23,6 @@ import io.renku.servers.SolrServer
 import io.renku.solr.client.{SolrClient, SolrConfig}
 import org.http4s.Uri
 
-import scala.concurrent.duration.Duration
-
 trait SolrServerSuite:
   self: munit.Suite =>
 
@@ -34,7 +32,6 @@ trait SolrServerSuite:
     Uri.unsafeFromString(server.url) / "solr",
     coreName,
     maybeUser = None,
-    commitWithin = Some(Duration.Zero),
     logMessageBodies = true
   )
 


### PR DESCRIPTION
To avoid dirty reads we need for now update with hard commits. In the future we can run certain updates in parallel.