### PR TITLE
feat: Create partial documents from ProjectUpdated messages

### DIFF
--- a/modules/search-provision/src/main/scala/io/renku/search/provision/events/Projects.scala
+++ b/modules/search-provision/src/main/scala/io/renku/search/provision/events/Projects.scala
@@ -66,3 +66,18 @@ trait Projects:
       visibility = pu.visibility.toModel.some,
       description = pu.description.map(_.toDescription)
     )
+
+  def fromProjectUpdated(
+      pu: ProjectUpdated,
+      version: DocVersion
+  ): PartialEntityDocument.Project =
+    PartialEntityDocument.Project(
+      id = pu.id.toId,
+      version = version,
+      name = pu.name.toName.some,
+      slug = pu.slug.toSlug.some,
+      repositories = pu.repositories.map(_.toRepository),
+      visibility = pu.visibility.toModel.some,
+      description = pu.description.map(_.toDescription),
+      keywords = pu.keywords.map(_.toKeyword).toList
+    )

--- a/modules/search-provision/src/main/scala/io/renku/search/provision/events/syntax.scala
+++ b/modules/search-provision/src/main/scala/io/renku/search/provision/events/syntax.scala
@@ -42,6 +42,8 @@ trait syntax extends io.renku.search.events.syntax:
       Conversion.fromProjectUpdated(self, orig)
     def toModel(orig: PartialEntityDocument.Project): PartialEntityDocument.Project =
       Conversion.fromProjectUpdated(self, orig)
+    def toModel(version: DocVersion): PartialEntityDocument.Project =
+      Conversion.fromProjectUpdated(self, version)
 
   extension (self: UserAdded)
     def toModel(version: DocVersion): UserDocument =

--- a/modules/search-provision/src/main/scala/io/renku/search/provision/handler/DocumentMerger.scala
+++ b/modules/search-provision/src/main/scala/io/renku/search/provision/handler/DocumentMerger.scala
@@ -99,7 +99,7 @@ object DocumentMerger:
     )
 
   given DocumentMerger[ProjectUpdated] =
-    instance[ProjectUpdated](_ => None)((pu, existing) =>
+    instance[ProjectUpdated](_.toModel(DocVersion.NotExists).some)((pu, existing) =>
       existing match
         case p: PartialEntityDocument.Project =>
           pu.toModel(p).some


### PR DESCRIPTION
This pr allows to first receive a project-update message and later a corresponding project-created message. The initial update message will be stored as a partial entity document (same as done already with project-auth-added)