### PR TITLE
Reduce content-type logging when decoding

### DIFF
--- a/modules/solr-client/src/test/scala/io/renku/solr/client/SolrClientSpec.scala
+++ b/modules/solr-client/src/test/scala/io/renku/solr/client/SolrClientSpec.scala
@@ -37,8 +37,6 @@ import org.scalacheck.Gen
 import org.scalacheck.effect.PropF
 
 class SolrClientSpec extends SolrClientBaseSuite with ScalaCheckEffectSuite:
-  override def defaultVerbosity: Int = 2
-
   test("optimistic locking: fail if exists"):
     withSolrClient().use { client =>
       val c0 = Course("c1", "fp in scala", DocVersion.NotExists)


### PR DESCRIPTION
- Try first json when decoding the message header, as this is sent from data services this way
- The payload must be decoded according to the `contentType` value in the message header