### PR TITLE
Extend solr client to support subqueries

### DIFF
--- a/modules/solr-client/src/main/scala/io/renku/solr/client/QueryData.scala
+++ b/modules/solr-client/src/main/scala/io/renku/solr/client/QueryData.scala
@@ -43,6 +43,12 @@ final case class QueryData(
   def withLimit(limit: Int): QueryData = copy(limit = limit)
   def withOffset(offset: Int): QueryData = copy(offset = offset)
 
+  def addSubQuery(field: FieldName, sq: SubQuery): QueryData =
+    copy(
+      params = params ++ sq.toParams(field),
+      fields = fields :+ FieldName(s"${field.name}:[subquery]")
+    )
+
 object QueryData:
 
   def apply(query: QueryString): QueryData =

--- a/modules/solr-client/src/main/scala/io/renku/solr/client/ResponseBody.scala
+++ b/modules/solr-client/src/main/scala/io/renku/solr/client/ResponseBody.scala
@@ -18,8 +18,8 @@
 
 package io.renku.solr.client
 
-import io.bullet.borer.Decoder
-import io.bullet.borer.derivation.MapBasedCodecs.deriveDecoder
+import io.bullet.borer.derivation.MapBasedCodecs
+import io.bullet.borer.{Decoder, Encoder}
 
 final case class ResponseBody[A](
     numFound: Long,
@@ -31,4 +31,5 @@ final case class ResponseBody[A](
     copy(docs = docs.map(f))
 
 object ResponseBody:
-  given [A](using Decoder[A]): Decoder[ResponseBody[A]] = deriveDecoder
+  given [A](using Decoder[A]): Decoder[ResponseBody[A]] = MapBasedCodecs.deriveDecoder
+  given [A](using Encoder[A]): Encoder[ResponseBody[A]] = MapBasedCodecs.deriveEncoder

--- a/modules/solr-client/src/main/scala/io/renku/solr/client/SolrSort.scala
+++ b/modules/solr-client/src/main/scala/io/renku/solr/client/SolrSort.scala
@@ -50,10 +50,10 @@ object SolrSort:
     def nonEmpty: Boolean = !self.isEmpty
     def ++(next: SolrSort): SolrSort =
       Monoid[SolrSort].combine(self, next)
+    private[client] def toSolr: String =
+      self.map { case (f, d) => s"${f.name} ${d.name}" }.mkString(",")
 
   given Monoid[SolrSort] =
     Monoid.instance(empty, (a, b) => if (a.isEmpty) b else if (b.isEmpty) a else a ++ b)
 
-  given Encoder[SolrSort] = Encoder.forString.contramap(list =>
-    list.map { case (f, d) => s"${f.name} ${d.name}" }.mkString(",")
-  )
+  given Encoder[SolrSort] = Encoder.forString.contramap(_.toSolr)

--- a/modules/solr-client/src/main/scala/io/renku/solr/client/SubQuery.scala
+++ b/modules/solr-client/src/main/scala/io/renku/solr/client/SubQuery.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.solr.client
+
+import cats.syntax.option.*
+
+import io.renku.solr.client.schema.FieldName
+
+final case class SubQuery(
+    query: String,
+    filter: String,
+    limit: Int,
+    offset: Int = 0,
+    fields: Seq[FieldName] = Seq.empty,
+    sort: SolrSort = SolrSort.empty
+):
+  def withSort(sort: SolrSort): SubQuery = copy(sort = sort)
+  def withFields(field: FieldName*) = copy(fields = field)
+  def withFilter(q: String): SubQuery = copy(filter = filter)
+  def withLimit(limit: Int): SubQuery = copy(limit = limit)
+  def withOffset(offset: Int): SubQuery = copy(offset = offset)
+
+  private[client] def toParams(field: FieldName): Map[String, String] =
+    def key(s: String): String = s"${field.name}.$s"
+    List(
+      (key("q") -> query).some,
+      Option.when(filter.nonEmpty)(key("fq") -> filter),
+      Option.when(limit >= 0)(key("limit") -> limit.toString),
+      Option.when(offset > 0)(key("offset") -> offset.toString),
+      Option.when(fields.nonEmpty)(key("fl") -> fields.mkString(",")),
+      Option.when(sort.nonEmpty)(key("sort") -> sort.toSolr)
+    ).collect { case Some(p) => p }.toMap


### PR DESCRIPTION
In order to return results from related documents, this adds support for using the [sub-query document transformer](https://solr.apache.org/guide/solr/latest/query-guide/document-transformers.html#subquery) to the solr-client library. 

Solr allows to run sub queries per document using a document
transformer. For this, a synthetic field needs to be added to the
field list of the main query and a `:[subquery]` appended to it, e.g.
`creator:[subquery]`. Then the actual sub query can be added to the
`params` section of the main query - prefixed by the field name. The
sub query works exactly like a main query, the parameters need only to
be prefixed so solr can do the query and associate the result
correctly. Solr will execute that query and adds the results as a
value to the defined field. The result is the complete `ResponseBody`,
including the header. So even if there are no results, there will be a
response object (containing an empty `docs` array).

The new case class `SubQuery` allows to specify such a sub query - it
looks very similar to `QueryData`, but doesn't define another `params`
and also doesn't define a `facet` parameter, because it is not needed.
When adding a sub query to a query, the queries `params` object is
updated accordingly and the new field is added to the field list. This
then requires to explicitly define a field list for the main query,
otherwise only the synthetic field will be returned as it is the only
one in the field list after a `SubQuery` has been added.


Issue: #146