### PR TITLE
Make jwt issuer url setting required

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -88,6 +88,7 @@
             RS_METRICS_UPDATE_INTERVAL = "0s";
             RS_SOLR_CREATE_CORE_CMD = "cnt-solr-create-core %s";
             RS_SOLR_DELETE_CORE_CMD = "cnt-solr-delete-core %s";
+            RS_JWT_ALLOWED_ISSUER_URL_PATTERNS = "renku.ch,*.renku.ch,*.*.renku.ch";
 
             #don't start docker container for dbTests
             NO_SOLR = "true";
@@ -113,6 +114,7 @@
             RS_METRICS_UPDATE_INTERVAL = "0s";
             RS_SOLR_CREATE_CORE_CMD = "vm-solr-create-core %s";
             RS_SOLR_DELETE_CORE_CMD = "vm-solr-delete-core %s";
+            RS_JWT_ALLOWED_ISSUER_URL_PATTERNS = "renku.ch,*.renku.ch,*.*.renku.ch";
 
             #don't start docker container for dbTests
             NO_SOLR = "true";

--- a/modules/config-values/src/main/scala/io/renku/search/config/ConfigValues.scala
+++ b/modules/config-values/src/main/scala/io/renku/search/config/ConfigValues.scala
@@ -101,7 +101,6 @@ object ConfigValues extends ConfigDecoders:
     val allowedIssuers =
       renv("JWT_ALLOWED_ISSUER_URL_PATTERNS")
         .as[List[UrlPattern]]
-        .default(defaults.allowedIssuerUrls)
     (requestDelay, enableSigCheck, openIdConfigPath, allowedIssuers).mapN(
       JwtVerifyConfig.apply
     )

--- a/modules/openid-keycloak/src/main/scala/io/renku/openid/keycloak/JwtVerifyConfig.scala
+++ b/modules/openid-keycloak/src/main/scala/io/renku/openid/keycloak/JwtVerifyConfig.scala
@@ -54,5 +54,5 @@ object JwtVerifyConfig:
     minRequestDelay = 1.minute,
     enableSignatureValidation = true,
     openIdConfigPath = ".well-known/openid-configuration",
-    List("*.*.renku.ch", "*.renku.ch", "renku.ch").map(UrlPattern.fromString)
+    Nil
   )


### PR DESCRIPTION
The url patterns for expected issuers must be set to be able to start the search api service. It can be set using environment variable `RS_JWT_ALLOWED_ISSUER_URL_PATTERNS`.