### PR TITLE
Allow to match the rest of a path for a url pattern

### DIFF
--- a/modules/commons/src/main/scala/io/renku/search/common/UrlPattern.scala
+++ b/modules/commons/src/main/scala/io/renku/search/common/UrlPattern.scala
@@ -29,17 +29,27 @@ final case class UrlPattern(
   def matches(url: String): Boolean =
     val parts = UrlPattern.splitUrl(url)
     scheme.forall(s => parts.scheme.exists(s.matches)) &&
-    (host.isEmpty || host.length == parts.host.length) &&
-    host.zip(parts.host).forall { case (s, h) => s.matches(h) } &&
+    matchList(parts.host, host) &&
     port.forall(p => parts.port.exists(p.matches)) &&
-    (path.isEmpty || path.length == parts.path.length) &&
-    path.zip(parts.path).forall { case (s, p) => s.matches(p) }
+    matchList(parts.path, path)
 
   def render: String =
     scheme.map(s => s"${s.render}://").getOrElse("") +
       host.map(_.render).mkString(".") +
       port.map(p => s":${p.render}").getOrElse("") +
       (if (path.isEmpty) "" else path.map(_.render).mkString("/", "/", ""))
+
+  private def matchList(values: List[String], pattern: List[Segment]): Boolean =
+    pattern.isEmpty || {
+      pattern.indexOf(Segment.MatchAllRemainder) match
+        case n if n < 0 =>
+          values.lengthIs == pattern.length && pattern.zip(values).forall { case (s, h) =>
+            s.matches(h)
+          }
+        case n =>
+          values.sizeIs >= n &&
+            pattern.take(n).zip(values).forall { case (s, h) => s.matches(h) }
+    }
 
 object UrlPattern:
   val all: UrlPattern = UrlPattern(None, Nil, None, Nil)
@@ -75,38 +85,54 @@ object UrlPattern:
         UrlParts(scheme, host, port, Nil)
   }
 
-  def fromString(str: String): UrlPattern =
-    if (str == "*" || str.isEmpty) UrlPattern.all
+  def fromString(str: String): Either[String, UrlPattern] =
+    if (str.isEmpty) Left("empty url pattern")
+    else if ("*" == str || "**" == str) Right(UrlPattern.all)
     else {
       val parts = splitUrl(str)
-      UrlPattern(
-        parts.scheme.map(Segment.fromString),
-        parts.host.map(Segment.fromString),
-        parts.port.map(Segment.fromString),
-        parts.path.map(Segment.fromString)
-      )
+      // specifiyng anything after a '**' doesn't make sense, so we detect
+      // it here and fail to convert to a pattern
+      // (no ** || last = **)
+      def check(segs: List[Segment]) =
+        val (pre, suf) = segs.span(_ != Segment.MatchAllRemainder)
+        if (suf.sizeIs <= 1) Right(segs)
+        else Left("A '**' should not be followed by other segments")
+
+      for
+        host <- check(parts.host.map(Segment.fromString))
+        path <- check(parts.path.map(Segment.fromString))
+        scheme = parts.scheme.map(Segment.fromString)
+        port = parts.port.map(Segment.fromString)
+      yield UrlPattern(scheme, host, port, path)
     }
+
+  def unsafeFromString(str: String): UrlPattern =
+    fromString(str).fold(sys.error, identity)
 
   enum Segment:
     case Literal(value: String)
     case Prefix(value: String)
     case Suffix(value: String)
     case MatchAll
+    case MatchAllRemainder
 
     def matches(value: String): Boolean = this match
-      case Literal(v) => v.equalsIgnoreCase(value)
-      case Prefix(v)  => value.startsWith(v)
-      case Suffix(v)  => value.endsWith(v)
-      case MatchAll   => true
+      case Literal(v)        => v.equalsIgnoreCase(value)
+      case Prefix(v)         => value.startsWith(v)
+      case Suffix(v)         => value.endsWith(v)
+      case MatchAll          => true
+      case MatchAllRemainder => true
 
     def render: String = this match
-      case Literal(v) => v
-      case Prefix(v)  => s"${v}*"
-      case Suffix(v)  => s"*${v}"
-      case MatchAll   => "*"
+      case Literal(v)        => v
+      case Prefix(v)         => s"${v}*"
+      case Suffix(v)         => s"*${v}"
+      case MatchAll          => "*"
+      case MatchAllRemainder => "**"
 
   object Segment:
     def fromString(s: String): Segment = s match
+      case "**"                   => MatchAllRemainder
       case "*"                    => MatchAll
       case x if x.startsWith("*") => Suffix(x.drop(1))
       case x if x.endsWith("*")   => Prefix(x.dropRight(1))

--- a/modules/commons/src/test/scala/io/renku/search/common/CommonGenerators.scala
+++ b/modules/commons/src/test/scala/io/renku/search/common/CommonGenerators.scala
@@ -31,22 +31,43 @@ object CommonGenerators:
     } yield NonEmptyList(e0, en)
 
   def urlPatternGen: Gen[UrlPattern] =
-    def segmentGen(inner: Gen[String]): Gen[UrlPattern.Segment] =
+    val allMatchBoth =
+      Gen.oneOf(UrlPattern.Segment.MatchAll, UrlPattern.Segment.MatchAllRemainder)
+    val allMatchOnly = Gen.const(UrlPattern.Segment.MatchAll)
+
+    def segmentGen(
+        inner: Gen[String],
+        other: Gen[UrlPattern.Segment]
+    ): Gen[UrlPattern.Segment] =
       Gen.oneOf(
         inner.map(s => UrlPattern.Segment.Prefix(s)),
         inner.map(s => UrlPattern.Segment.Suffix(s)),
         inner.map(s => UrlPattern.Segment.Literal(s)),
-        Gen.const(UrlPattern.Segment.MatchAll)
+        other
       )
 
-    val schemes = segmentGen(Gen.oneOf("http", "https"))
-    val ports = segmentGen(Gen.oneOf("123", "8080", "8145", "487", "11"))
-    val hosts = segmentGen(
-      Gen.oneOf("test", "com", "ch", "de", "dev", "renku", "penny", "cycle")
-    ).asListOfN(0, 5)
-    val paths = segmentGen(
-      Gen.oneOf("auth", "authenticate", "doAuth", "me", "run", "api")
-    ).asListOfN(0, 5)
+    def appendMatchRemainder(
+        g: Gen[List[UrlPattern.Segment]]
+    ): Gen[List[UrlPattern.Segment]] =
+      for
+        segs <- g
+        rem <- Gen.option(Gen.const(UrlPattern.Segment.MatchAllRemainder))
+      yield segs ++ rem.toList
+
+    val schemes = segmentGen(Gen.oneOf("http", "https"), allMatchBoth)
+    val ports = segmentGen(Gen.oneOf("123", "8080", "8145", "487", "11"), allMatchBoth)
+    val hosts = appendMatchRemainder(
+      segmentGen(
+        Gen.oneOf("test", "com", "ch", "de", "dev", "renku", "penny", "cycle"),
+        allMatchOnly
+      ).asListOfN(0, 4)
+    )
+    val paths = appendMatchRemainder(
+      segmentGen(
+        Gen.oneOf("auth", "authenticate", "doAuth", "me", "run", "api"),
+        allMatchOnly
+      ).asListOfN(0, 4)
+    )
     for
       scheme <- schemes.asOption
       host <- hosts

--- a/modules/openid-keycloak/src/test/scala/io/renku/openid/keycloak/DefaultJwtVerifySpec.scala
+++ b/modules/openid-keycloak/src/test/scala/io/renku/openid/keycloak/DefaultJwtVerifySpec.scala
@@ -43,7 +43,7 @@ class DefaultJwtVerifySpec
 
   val issuer: Uri = uri"https://ci-renku-3622.dev.renku.ch/auth/realms/Renku"
   val jwtConfig = JwtVerifyConfig.default.copy(allowedIssuerUrls =
-    List(UrlPattern.fromString("*.*.renku.ch"))
+    List(UrlPattern.unsafeFromString("*.*.renku.ch"))
   )
 
   extension [B](self: Either[JwtError, B])
@@ -152,7 +152,7 @@ class DefaultJwtVerifySpec
 
   test("stop on invalid issuer"):
     val testClient = Client.fromHttpApp(HttpRoutes.empty[IO].orNotFound)
-    val allowedIssuers = List(UrlPattern.fromString("*.myserver.com"))
+    val allowedIssuers = List(UrlPattern.unsafeFromString("*.myserver.com"))
     for
       verifyer <- DefaultJwtVerify(
         testClient,


### PR DESCRIPTION
A `**` can be used to match everything after without restriction. This can be used to match remaining segments of a path, for example.