### PR TITLE
Additionally mount search endpoint to /api/search/query

### DIFF
--- a/modules/search-api/src/main/scala/io/renku/search/api/Routes.scala
+++ b/modules/search-api/src/main/scala/io/renku/search/api/Routes.scala
@@ -53,8 +53,6 @@ final class Routes[F[_]: Async: Network](
 ):
   private val logger = scribe.cats.effect[F]
 
-  private val prefix = "/search"
-
   private val makeJwtVerify =
     ClientBuilder(EmberClientBuilder.default[F])
       .withDefaultRetry(RetryConfig.default)
@@ -71,11 +69,13 @@ final class Routes[F[_]: Async: Network](
 
   private def searchHttpRoutes(searchRoutes: SearchRoutes[F]) =
     Router[F](
-      prefix -> (openApiRoute(searchRoutes).routes <+> searchRoutes.routes)
+      "/search" -> (openApiRoute(searchRoutes).routes <+> searchRoutes.routes),
+      "/api/search/query" -> (openApiRoute(searchRoutes).routes <+> searchRoutes.routes),
+      "/search/query" -> (openApiRoute(searchRoutes).routes <+> searchRoutes.routes)
     )
 
   private def openApiRoute(searchRoutes: SearchRoutes[F]) =
-    OpenApiRoute[F](s"/api$prefix", "Renku Search API", searchRoutes.endpoints)
+    OpenApiRoute[F](s"/api/search/query", "Renku Search API", searchRoutes.endpoints)
 
   private lazy val operationHttpRoutes =
     Router[F]("/" -> OperationRoutes[F])


### PR DESCRIPTION
This little change is meant as preparation to mount the search endpoint in a more flexible way and to finally allow to provide a `/version` endpoint for the (entire) search service.

The idea is that we remove the `stripPrefix` in gateway and pass the request as-is to the search service. The current public path should not change, therefore it stays as `/api/search` and the current "search" endpoint will be `/api/search/query`. Later a version `/api/search/version` and potentially other public endpoints can be provided easily without changing gateway. Currently it is not possible to provide more endpoints without editing the gateway configuration (besides putting everything under `/search` which is too strange).

This commit allows clients (UI) to use the new path for doing search queries, while the old path stays enabled as well.