### PR TITLE
Set docker daemon user to 'ubuntu'

### DIFF
--- a/project/DockerImagePlugin.scala
+++ b/project/DockerImagePlugin.scala
@@ -21,8 +21,8 @@ object DockerImagePlugin extends AutoPlugin {
     // dockerEntrypoint    := Seq(s"bin/${executableScriptName.value}", "-Duser.timezone=UTC", "$JAVA_OPTS"),
     dockerBaseImage := s"eclipse-temurin:21-jre",
     // deamon uuid 1000 required by renku pod security context
-    Docker / daemonUserUid := Some("1000"),
-    Docker / daemonUser := "searchuser",
+    Docker / daemonUserUid := None,
+    Docker / daemonUser := "ubuntu", // current eclipse-temurin:21-jre has ubuntu user with uid 1000 pre-installed :/
     // derive a package name
     Docker / packageName := (Compile / name).value,
     dockerRepository := Some("docker.io"),


### PR DESCRIPTION
The current `eclipse-temurin:21-jre` image has now a user already present with `uid=1000`. So creating `searchuser` fails when building the image. The comment above indicates, that it is necessary to have a user with this specific `uid=1000`. So this change switches to the pre-installed `ubuntu` user to fix this.