### PR TITLE
Fix casing in api docs for visibility values

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -66,7 +66,7 @@
         groupMemberAdded = "groupMemberAdded";
         groupMemberUpdated = "groupMemberUpdated";
         groupMemberRemoved = "groupMemberRemoved";
-        searchSync = "searchSync";
+        searchSync = "search.sync";
       };
 
       queueNameConfig = with nixpkgs.lib; mapAttrs' (key: qn: nameValuePair "RS_REDIS_QUEUE_${key}" qn) queueNames;

--- a/modules/commons/src/main/scala/io/renku/search/model/Visibility.scala
+++ b/modules/commons/src/main/scala/io/renku/search/model/Visibility.scala
@@ -27,6 +27,8 @@ enum Visibility:
   lazy val name: String = productPrefix.toLowerCase
   case Public, Private
 
+  override def toString(): String = name
+
 object Visibility:
   given Order[Visibility] = Order.by(_.ordinal)
   given Encoder[Visibility] = Encoder.forString.contramap(_.name)


### PR DESCRIPTION
The API docs should show lower case visibility values, as they are returned from the server.

Closes: #160 