### PR TITLE
Allow to re-create the index from the redis stream

### DIFF
--- a/modules/events/src/main/scala/io/renku/search/events/MessageId.scala
+++ b/modules/events/src/main/scala/io/renku/search/events/MessageId.scala
@@ -18,6 +18,8 @@
 
 package io.renku.search.events
 
+import io.bullet.borer.*
+
 opaque type MessageId = String
 
 object MessageId:
@@ -25,3 +27,6 @@ object MessageId:
   def apply(id: String): MessageId = id
 
   extension (self: MessageId) def value: String = self
+
+  given Decoder[MessageId] = Decoder.forString
+  given Encoder[MessageId] = Encoder.forString

--- a/modules/renku-redis-client/src/main/scala/io/renku/queue/client/QueueClient.scala
+++ b/modules/renku-redis-client/src/main/scala/io/renku/queue/client/QueueClient.scala
@@ -58,6 +58,8 @@ trait QueueClient[F[_]]:
 
   def findLastProcessed(queueNames: NonEmptyList[QueueName]): F[Option[MessageId]]
 
+  def removeLastProcessed(queueNames: NonEmptyList[QueueName]): F[Unit]
+
   def getSize(queueName: QueueName): F[Long]
 
   def getSize(queueName: QueueName, from: MessageId): F[Long]

--- a/modules/renku-redis-client/src/main/scala/io/renku/queue/client/QueueClientImpl.scala
+++ b/modules/renku-redis-client/src/main/scala/io/renku/queue/client/QueueClientImpl.scala
@@ -105,6 +105,9 @@ private class QueueClientImpl[F[_]: Async](
   ): F[Option[MessageId]] =
     redisQueueClient.findLastProcessed(clientId, queueNames).map(_.map(MessageId.apply))
 
+  override def removeLastProcessed(queueNames: NonEmptyList[QueueName]): F[Unit] =
+    redisQueueClient.removeLastProcessed(clientId, queueNames)
+
   override def getSize(queueName: QueueName): F[Long] =
     redisQueueClient.getSize(queueName)
 

--- a/modules/search-provision/src/main/scala/io/renku/search/provision/Services.scala
+++ b/modules/search-provision/src/main/scala/io/renku/search/provision/Services.scala
@@ -24,6 +24,7 @@ import fs2.io.net.Network
 
 import io.renku.queue.client.QueueClient
 import io.renku.search.provision.handler.PipelineSteps
+import io.renku.search.provision.reindex.ReIndexService
 import io.renku.search.solr.client.SearchSolrClient
 
 final case class Services[F[_]](
@@ -31,7 +32,8 @@ final case class Services[F[_]](
     solrClient: SearchSolrClient[F],
     queueClient: Stream[F, QueueClient[F]],
     messageHandlers: MessageHandlers[F],
-    backgroundManage: BackgroundProcessManage[F]
+    backgroundManage: BackgroundProcessManage[F],
+    reIndex: ReIndexService[F]
 )
 
 object Services:
@@ -52,4 +54,6 @@ object Services:
       handlers = MessageHandlers[F](steps, cfg.queuesConfig)
 
       bm <- BackgroundProcessManage[F](cfg.retryOnErrorDelay)
-    } yield Services(cfg, solr, redis, handlers, bm)
+
+      ris = ReIndexService[F](bm, redis, solr, cfg.queuesConfig)
+    } yield Services(cfg, solr, redis, handlers, bm, ris)

--- a/modules/search-provision/src/main/scala/io/renku/search/provision/Services.scala
+++ b/modules/search-provision/src/main/scala/io/renku/search/provision/Services.scala
@@ -30,7 +30,8 @@ final case class Services[F[_]](
     config: SearchProvisionConfig,
     solrClient: SearchSolrClient[F],
     queueClient: Stream[F, QueueClient[F]],
-    messageHandlers: MessageHandlers[F]
+    messageHandlers: MessageHandlers[F],
+    backgroundManage: BackgroundProcessManage[F]
 )
 
 object Services:
@@ -49,4 +50,6 @@ object Services:
         inChunkSize = 1
       )
       handlers = MessageHandlers[F](steps, cfg.queuesConfig)
-    } yield Services(cfg, solr, redis, handlers)
+
+      bm <- BackgroundProcessManage[F](cfg.retryOnErrorDelay)
+    } yield Services(cfg, solr, redis, handlers, bm)

--- a/modules/search-provision/src/main/scala/io/renku/search/provision/reindex/ReIndexDocument.scala
+++ b/modules/search-provision/src/main/scala/io/renku/search/provision/reindex/ReIndexDocument.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.search.provision.reindex
+
+import java.time.Instant
+
+import cats.Functor
+import cats.effect.*
+import cats.syntax.all.*
+
+import io.bullet.borer.Decoder
+import io.bullet.borer.Encoder
+import io.bullet.borer.derivation.{MapBasedCodecs, key}
+import io.renku.json.codecs.all.given
+import io.renku.search.events.MessageId
+import io.renku.search.model.Id
+import io.renku.solr.client.DocVersion
+
+final private case class ReIndexDocument(
+    id: Id,
+    created: Instant,
+    messageId: Option[MessageId],
+    @key("_version_") version: DocVersion
+)
+
+private object ReIndexDocument:
+  private val docId: Id = Id("reindex_31baded5-9fc2-4935-9b07-80f7a3ecb13f")
+
+  def createNew[F[_]: Clock: Functor](messageId: Option[MessageId]): F[ReIndexDocument] =
+    Clock[F].realTimeInstant.map { now =>
+      ReIndexDocument(docId, now, messageId, DocVersion.NotExists)
+    }
+
+  given Encoder[ReIndexDocument] = MapBasedCodecs.deriveEncoder
+  given Decoder[ReIndexDocument] = MapBasedCodecs.deriveDecoder

--- a/modules/search-provision/src/main/scala/io/renku/search/provision/reindex/ReIndexService.scala
+++ b/modules/search-provision/src/main/scala/io/renku/search/provision/reindex/ReIndexService.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2024 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.search.provision.reindex
+
+import cats.data.NonEmptyList
+import cats.effect.*
+import cats.syntax.all.*
+import fs2.Stream
+
+import io.renku.queue.client.QueueClient
+import io.renku.search.config.QueuesConfig
+import io.renku.search.events.MessageId
+import io.renku.search.provision.BackgroundProcessManage
+import io.renku.search.provision.MessageHandlers.MessageHandlerKey
+import io.renku.search.solr.client.SearchSolrClient
+
+trait ReIndexService[F[_]]:
+  def startReIndex(startMessage: Option[MessageId]): F[Boolean]
+
+object ReIndexService:
+
+  def apply[F[_]: Clock: Sync](
+      bpm: BackgroundProcessManage[F],
+      redisClient: Stream[F, QueueClient[F]],
+      solrClient: SearchSolrClient[F],
+      queueCfg: QueuesConfig
+  ): ReIndexService[F] =
+    new ReIndexService[F] {
+      private val queueName = NonEmptyList.of(queueCfg.dataServiceAllEvents)
+      private val logger = scribe.cats.effect[F]
+
+      def startReIndex(startMessage: Option[MessageId]): F[Boolean] =
+        for
+          syncDoc <- ReIndexDocument.createNew[F](startMessage)
+          upsertResp <- solrClient.upsert(Seq(syncDoc))
+          _ <- logger.debug(s"Insert reindex sync document: $upsertResp")
+          res <-
+            if (upsertResp.isFailure)
+              logger.debug(s"Re-Index called while already in progress").as(false)
+            else dropIndexAndRestart(syncDoc, startMessage)
+        yield res
+
+      private def dropIndexAndRestart(
+          syncDoc: ReIndexDocument,
+          startMessage: Option[MessageId]
+      ) =
+        for
+          _ <- logger.info(
+            s"Starting re-indexing all data, since message ${syncDoc.messageId}"
+          )
+          _ <- bpm.cancelProcesses(MessageHandlerKey.isInstance)
+          _ <- logger.info("Background processes stopped")
+          _ <- startMessage match
+            case Some(msgId) =>
+              logger.info("Set last seen message id to $msgId for $queueName") >>
+                redisClient
+                  .evalMap(_.markProcessed(queueName, msgId))
+                  .take(1)
+                  .compile
+                  .drain
+            case None =>
+              // a special case until the other queues are removed and
+              // only `data_service.all_events` is left. we remove the
+              // last seen message-ids from all queue names, in
+              // contrast for setting a message-id which can only be
+              // done for one queue (and doesn't make sense to
+              // implement for all)
+              logger.info(s"Remove last processed message id for ${queueCfg.all}") >>
+                redisClient
+                  .evalMap(rc =>
+                    queueCfg.all.toList.traverse_(q =>
+                      rc.removeLastProcessed(NonEmptyList.of(q))
+                    )
+                  )
+                  .take(1)
+                  .compile
+                  .drain
+          _ <- logger.info("Delete SOLR index")
+          _ <- solrClient.deletePublicData
+          _ <- logger.info("Start background processes")
+          _ <- bpm.background(MessageHandlerKey.isInstance)
+          _ <- solrClient.deleteIds(NonEmptyList.of(syncDoc.id))
+        yield true
+    }

--- a/modules/search-provision/src/test/scala/io/renku/search/provision/BackgroundProcessManageSpec.scala
+++ b/modules/search-provision/src/test/scala/io/renku/search/provision/BackgroundProcessManageSpec.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2024 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.search.provision
+
+import scala.concurrent.duration.*
+
+import cats.effect.*
+import fs2.Stream
+
+import io.renku.search.LoggingConfigure
+import io.renku.search.provision.BackgroundProcessManageSpec.Key
+import munit.CatsEffectSuite
+
+class BackgroundProcessManageSpec extends CatsEffectSuite with LoggingConfigure:
+
+  def makeInfiniteTask(effect: IO[Unit], pause: FiniteDuration = 20.millis) = Stream
+    .repeatEval(effect)
+    .interleave(Stream.sleep[IO](pause).repeat)
+    .compile
+    .drain
+
+  val manager = BackgroundProcessManage[IO](10.millis)
+
+  test("register tasks, start and cancel"):
+    manager.use { m =>
+      for
+        counter <- Ref[IO].of(0)
+        task = makeInfiniteTask(counter.update(_ + 1))
+        _ <- m.register(Key.Count, task)
+        _ <- m.startAll
+        ps <- m.currentProcesses
+        _ = assertEquals(ps, Set(Key.Count.widen))
+
+        _ <- IO.sleep(50.millis)
+        _ <- m.cancelProcesses(_ => true)
+        ps2 <- m.currentProcesses
+        _ = assert(ps2.isEmpty)
+        _ <- IO.sleep(50.millis)
+        n <- counter.get
+        _ = assert(n >= 1 && n <= 3, s"$n is not between 1 and 3 (inclusive)")
+      yield ()
+    }
+
+  test("remove process when done"):
+    manager.use { m =>
+      for
+        _ <- m.register(Key.Nothing, IO.unit)
+        _ <- m.startAll
+        _ <- IO.sleep(10.millis)
+        ps <- m.currentProcesses
+        _ = assert(ps.isEmpty)
+      yield ()
+    }
+
+  test("restart on error"):
+    manager.use { m =>
+      for
+        counter <- Ref[IO].of(0)
+        task = makeInfiniteTask(counter.updateAndGet(_ + 1).flatMap { n =>
+          if (n % 3 == 0) IO.raiseError(new Exception("boom")) else IO.unit
+        })
+        _ <- m.register(Key.Errors, task)
+        _ <- m.startAll
+        _ <- IO.sleep(100.millis)
+        _ <- m.cancelProcesses(_ => true)
+        n <- counter.get
+        _ = assert(n > 3, s"$n is not greater than 3")
+      yield ()
+    }
+
+object BackgroundProcessManageSpec:
+
+  enum Key extends BackgroundProcessManage.TaskName:
+    case Count
+    case Errors
+    case Nothing
+
+    def widen: BackgroundProcessManage.TaskName = this

--- a/modules/search-provision/src/test/scala/io/renku/search/provision/TestServices.scala
+++ b/modules/search-provision/src/test/scala/io/renku/search/provision/TestServices.scala
@@ -23,13 +23,16 @@ import cats.effect.*
 import io.renku.queue.client.QueueClient
 import io.renku.redis.client.QueueName
 import io.renku.search.provision.handler.PipelineSteps
+import io.renku.search.provision.reindex.ReIndexService
 import io.renku.search.solr.client.SearchSolrClient
 
 final case class TestServices(
     pipelineSteps: QueueName => PipelineSteps[IO],
     messageHandlers: MessageHandlers[IO],
     queueClient: QueueClient[IO],
-    searchClient: SearchSolrClient[IO]
+    searchClient: SearchSolrClient[IO],
+    backgroundManage: BackgroundProcessManage[IO],
+    reindex: ReIndexService[IO]
 ):
 
   def syncHandler(qn: QueueName): SyncMessageHandler[IO] =

--- a/modules/search-provision/src/test/scala/io/renku/search/provision/reindex/ReIndexServiceSpec.scala
+++ b/modules/search-provision/src/test/scala/io/renku/search/provision/reindex/ReIndexServiceSpec.scala
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2024 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.search.provision.reindex
+
+import scala.concurrent.duration.*
+
+import cats.effect.*
+import fs2.Stream
+
+import io.renku.events.EventsGenerators
+import io.renku.redis.client.QueueName
+import io.renku.redis.client.RedisClientGenerators
+import io.renku.search.GeneratorSyntax.*
+import io.renku.search.config.QueuesConfig
+import io.renku.search.model.Name
+import io.renku.search.provision.MessageHandlers.MessageHandlerKey
+import io.renku.search.provision.ProvisioningSuite
+import io.renku.search.provision.TestServices
+import io.renku.search.solr.documents.{EntityDocument, Project as ProjectDocument}
+import io.renku.search.solr.schema.EntityDocumentSchema
+import io.renku.solr.client.DocVersion
+import io.renku.solr.client.QueryData
+import io.renku.solr.client.QueryString
+import io.renku.solr.client.SolrSort
+import org.scalacheck.Gen
+
+class ReIndexServiceSpec extends ProvisioningSuite:
+
+  override val queueConfig: QueuesConfig =
+    ProvisioningSuite.queueConfig.copy(dataServiceAllEvents =
+      RedisClientGenerators.queueNameGen.generateOne
+    )
+
+  val allQuery: QueryData =
+    QueryData(QueryString("_kind:*", 10, 0))
+      .withSort(SolrSort(EntityDocumentSchema.Fields.id -> SolrSort.Direction.Asc))
+
+  def waitForSolrDocs(services: TestServices, size: Int): IO[List[EntityDocument]] =
+    Stream
+      .repeatEval(
+        services.searchClient
+          .queryAll[EntityDocument](allQuery)
+          .compile
+          .toList
+      )
+      .takeThrough(_.size != size)
+      .meteredStartImmediately(15.millis)
+      .timeout(5.minutes)
+      .compile
+      .lastOrError
+
+  test("re-index restores data from redis stream"):
+    for
+      services <- IO(testServices())
+      _ <- services.backgroundManage.register(
+        MessageHandlerKey.DataServiceAllEvents,
+        services.syncHandler(queueConfig.dataServiceAllEvents).create.compile.drain
+      )
+      _ <- services.backgroundManage.startAll
+      proj1 <- IO(EventsGenerators.projectCreatedGen("p1").generateOne)
+      proj2 <- IO(EventsGenerators.projectCreatedGen("p2").generateOne)
+      msg1 <- IO(EventsGenerators.eventMessageGen(Gen.const(proj1)).generateOne)
+      msg2 <- IO(EventsGenerators.eventMessageGen(Gen.const(proj2)).generateOne)
+      mId1 <- services.queueClient.enqueue(queueConfig.dataServiceAllEvents, msg1)
+      mId2 <- services.queueClient.enqueue(queueConfig.dataServiceAllEvents, msg2)
+
+      docs <- waitForSolrDocs(services, 2)
+      _ = assertEquals(docs.size, 2)
+
+      // corrupt the data at solr
+      _ <- services.searchClient.upsert(
+        Seq(docs.head.asInstanceOf[ProjectDocument].copy(name = Name("blaaah")))
+      )
+      changed <- services.searchClient
+        .queryAll[EntityDocument](allQuery)
+        .compile
+        .toList
+      _ = assertEquals(changed.size, 2)
+      _ = assertNotEquals(changed, docs)
+
+      // now run re-indexing from beginning when this returns,
+      _ <- services.reindex.startReIndex(None)
+      // re-indexing has been initiated, meaning that solr has been
+      // cleared and background processes restarted. So only need to
+      // wait for the 2 documents to reappear
+      docs2 <- waitForSolrDocs(services, 2)
+      _ = assertEquals(docs2.size, 2)
+
+      // afterwards, the initial state should be re-created
+      _ = assertEquals(
+        docs2.map(_.setVersion(DocVersion.Off)),
+        docs.map(_.setVersion(DocVersion.Off))
+      )
+    yield ()
+
+  test("re-index should not start when running already"):
+    for
+      services <- IO(testServices())
+
+      doc <- ReIndexDocument.createNew[IO](None)
+      _ <- services.searchClient.upsertSuccess(Seq(doc))
+
+      r <- services.reindex.startReIndex(None)
+      _ = assertEquals(r, false)
+    yield ()

--- a/modules/search-solr-client/src/main/scala/io/renku/search/solr/client/SearchSolrClient.scala
+++ b/modules/search-solr-client/src/main/scala/io/renku/search/solr/client/SearchSolrClient.scala
@@ -31,6 +31,7 @@ import io.renku.search.solr.documents.*
 import io.renku.solr.client.*
 
 trait SearchSolrClient[F[_]]:
+  private[solr] def underlying: SolrClient[F]
   def findById[D: Decoder](id: CompoundId): F[Option[D]]
   def upsert[D: Encoder](documents: Seq[D]): F[UpsertResponse]
   def upsertSuccess[D: Encoder](documents: Seq[D]): F[Unit]
@@ -43,6 +44,7 @@ trait SearchSolrClient[F[_]]:
       offset: Int
   ): F[QueryResponse[EntityDocument]]
   def queryAll[D: Decoder](query: QueryData): Stream[F, D]
+  def deletePublicData: F[Unit]
 
 object SearchSolrClient:
   def make[F[_]: Async: Network](

--- a/modules/search-solr-client/src/main/scala/io/renku/search/solr/client/SearchSolrClientImpl.scala
+++ b/modules/search-solr-client/src/main/scala/io/renku/search/solr/client/SearchSolrClientImpl.scala
@@ -29,6 +29,7 @@ import io.renku.search.query.Query
 import io.renku.search.solr.SearchRole
 import io.renku.search.solr.documents.*
 import io.renku.search.solr.query.LuceneQueryInterpreter
+import io.renku.search.solr.query.SolrToken
 import io.renku.search.solr.schema.EntityDocumentSchema
 import io.renku.solr.client.*
 import io.renku.solr.client.facet.{Facet, Facets}
@@ -47,6 +48,7 @@ private class SearchSolrClientImpl[F[_]: Async](solrClient: SolrClient[F])
     EntityDocumentSchema.Fields.entityType,
     EntityDocumentSchema.Fields.entityType
   )
+  private[solr] val underlying: SolrClient[F] = solrClient
 
   override def upsert[D: Encoder](documents: Seq[D]): F[UpsertResponse] =
     solrClient.upsert(documents)
@@ -105,3 +107,6 @@ private class SearchSolrClientImpl[F[_]: Async](solrClient: SolrClient[F])
     solrClient
       .query(id.toQueryData)
       .map(_.responseBody.docs.headOption)
+
+  override def deletePublicData: F[Unit] =
+    solrClient.delete(QueryString(SolrToken.kindExists.value))

--- a/modules/search-solr-client/src/main/scala/io/renku/search/solr/query/SolrToken.scala
+++ b/modules/search-solr-client/src/main/scala/io/renku/search/solr/query/SolrToken.scala
@@ -54,6 +54,9 @@ object SolrToken:
   def kindIs(kind: DocumentKind): SolrToken =
     fieldIs(SolrField.kind, kind.name)
 
+  def kindExists: SolrToken =
+    fieldIs(SolrField.kind, "*")
+
   def fromInstant(ts: Instant): SolrToken = StringEscape.escape(ts.toString, ":")
   def fromDateRange(min: Instant, max: Instant): SolrToken = s"[$min TO $max]"
 

--- a/nix/dev-scripts.nix
+++ b/nix/dev-scripts.nix
@@ -8,6 +8,16 @@
     inherit system;
   };
 
+  redis-list-streams = devshell-tools.lib.installScript {
+    script = ./scripts/redis-list-streams;
+    inherit system;
+  };
+
+  redis-stream-info = devshell-tools.lib.installScript {
+    script = ./scripts/redis-stream-info;
+    inherit system;
+  };
+
   k8s-reprovision = devshell-tools.lib.installScript {
     script = ./scripts/k8s-reprovision;
     inherit system;

--- a/nix/scripts/redis-list-streams
+++ b/nix/scripts/redis-list-streams
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+host="${RS_REDIS_HOST:-localhost}"
+if [ -n "$1" ]; then
+    host="$1"
+fi
+port="${RS_REDIS_PORT:-6379}"
+if [ -n "$2" ]; then
+    port="$2"
+fi
+db_opt=""
+if [ -n "$RS_REDIS_DB" ]; then
+    db_opt="-n $RS_REDIS_DB"
+fi
+db_pass=""
+if [ -n "$RS_REDIS_PASSWORD" ]; then
+    db_pass="-a $RS_REDIS_PASSWORD"
+fi
+
+redis-cli -e --json -h "$host" -p "$port" $db_opt $db_pass scan 0 type stream | jq -r '.[1][]'

--- a/nix/scripts/redis-stream-info
+++ b/nix/scripts/redis-stream-info
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+host="${RS_REDIS_HOST:-localhost}"
+port="${RS_REDIS_PORT:-6379}"
+db_opt=""
+if [ -n "$RS_REDIS_DB" ]; then
+    db_opt="-n $RS_REDIS_DB"
+fi
+db_pass=""
+if [ -n "$RS_REDIS_PASSWORD" ]; then
+    db_pass="-a $RS_REDIS_PASSWORD"
+fi
+redis-cli -e --json -h "$host" -p "$port" $db_opt $db_pass XINFO STREAM "$1"


### PR DESCRIPTION
Exposes an endpoint on the search-provision service to drop the current index and re-read everything from the redis stream. This allows to re-create the entire index from the raw data.