### PR TITLE
Log when decoding http messages fail and on internal errors

### DIFF
--- a/modules/http4s-commons/src/main/scala/io/renku/search/http/HttpServer.scala
+++ b/modules/http4s-commons/src/main/scala/io/renku/search/http/HttpServer.scala
@@ -19,29 +19,65 @@
 package io.renku.search.http
 
 import cats.effect.{Async, Resource}
+import cats.syntax.all.*
 import fs2.io.net.Network
-import org.http4s.HttpRoutes
+import org.http4s.*
 import org.http4s.ember.server.EmberServerBuilder
+import org.http4s.server.middleware.Logger as Http4sLogger
 import org.http4s.server.Server
 import org.http4s.HttpApp
+import scribe.Scribe
+
+final class HttpServer[F[_]: Async](
+    builder: EmberServerBuilder[F],
+    middlewares: List[HttpApp[F] => HttpApp[F]]
+):
+  def build: Resource[F, Server] = builder.build
+
+  def modify(f: EmberServerBuilder[F] => EmberServerBuilder[F]): HttpServer[F] =
+    new HttpServer[F](f(builder), Nil)
+
+  def withConfig(config: HttpServerConfig): HttpServer[F] =
+    modify(
+      _.withHost(config.bindAddress)
+        .withPort(config.port)
+        .withShutdownTimeout(config.shutdownTimeout)
+    )
+
+  def withDefaultErrorHandler(logger: Scribe[F]) =
+    modify(_.withErrorHandler {
+      case ex: DecodeFailure =>
+        logger
+          .warn("Error decoding message!", ex)
+          .as(ex.toHttpResponse(HttpVersion.`HTTP/1.1`))
+      case ex =>
+        logger
+          .error("Service raised an error!", ex)
+          .as(Response(status = Status.InternalServerError))
+    })
+
+  def withMiddleware(m: HttpApp[F] => HttpApp[F]): HttpServer[F] =
+    new HttpServer[F](builder, m :: middlewares)
+
+  def withDefaultLogging(logger: Scribe[F]) =
+    withMiddleware(
+      Http4sLogger.httpApp(
+        logHeaders = true,
+        logBody = false,
+        logAction = Some(msg => logger.debug(msg))
+      )
+    )
+
+  def withHttpApp(app: HttpApp[F]) =
+    val applied = middlewares.foldLeft(app)((r, mf) => mf(r))
+    modify(_.withHttpApp(applied))
+
+  def withHttpRoutes(routes: HttpRoutes[F]) =
+    withHttpApp(routes.orNotFound)
 
 object HttpServer:
+  def default[F[_]: Async: Network]: HttpServer[F] =
+    new HttpServer[F](EmberServerBuilder.default[F], Nil)
 
-  def apply[F[_]: Async: Network](config: HttpServerConfig): EmberServerBuilder[F] =
-    EmberServerBuilder
-      .default[F]
-      .withHost(config.bindAddress)
-      .withPort(config.port)
-      .withShutdownTimeout(config.shutdownTimeout)
-
-  def build[F[_]: Async: Network](
-      routes: HttpRoutes[F],
-      config: HttpServerConfig
-  ): Resource[F, Server] =
-    apply[F](config).withHttpApp(routes.orNotFound).build
-
-  def buildApp[F[_]: Async: Network](
-      app: HttpApp[F],
-      config: HttpServerConfig
-  ): Resource[F, Server] =
-    apply[F](config).withHttpApp(app).build
+  def apply[F[_]: Async: Network](config: HttpServerConfig): HttpServer[F] =
+    default[F].withConfig(config)

--- a/modules/search-api/src/main/scala/io/renku/search/api/SearchServer.scala
+++ b/modules/search-api/src/main/scala/io/renku/search/api/SearchServer.scala
@@ -36,7 +36,9 @@ object SearchServer:
   def create[F[_]: Async: Network](config: SearchApiConfig, app: ServiceRoutes[F]) =
     for
       routes <- makeHttpRoutes(app)
+      logger = scribe.cats.effect[F]
       server <- HttpServer[F](config.httpServerConfig)
+        .withDefaultErrorHandler(logger)
         .withHttpApp(routes.orNotFound)
         .build
     yield server

--- a/modules/search-provision/src/main/scala/io/renku/search/provision/Microservice.scala
+++ b/modules/search-provision/src/main/scala/io/renku/search/provision/Microservice.scala
@@ -65,7 +65,13 @@ object Microservice extends IOApp:
       services: Services[IO]
   ): (TaskName, IO[Unit]) =
     val io = Routes[IO](registryBuilder, services)
-      .flatMap(HttpServer.build(_, services.config.httpServerConfig))
+      .flatMap(routes =>
+        HttpServer[IO](services.config.httpServerConfig)
+          .withDefaultErrorHandler(logger)
+          .withDefaultLogging(logger)
+          .withHttpRoutes(routes)
+          .build
+      )
       .use(_ => IO.never)
     TaskName.fromString("http server") -> io
 


### PR DESCRIPTION
When message decoding fails, a BadRequest is returned, other errors are mapped to InternalServerError.