### PR TITLE
Run schema migration commands only if not already applied

### DIFF
--- a/modules/search-provision/src/main/scala/io/renku/search/provision/Microservice.scala
+++ b/modules/search-provision/src/main/scala/io/renku/search/provision/Microservice.scala
@@ -40,6 +40,10 @@ object Microservice extends IOApp:
       for {
         _ <- IO(LoggingSetup.doConfigure(services.config.verbosity))
         migrateResult <- runSolrMigrations(services.config)
+        _ <- IO.whenA(migrateResult.migrationsSkipped > 0)(
+          logger
+            .warn(s"There were ${migrateResult.migrationsSkipped} skipped migrations!")
+        )
         // this is only safe for a single provisioning service
         _ <- services.resetLockDocuments
         registryBuilder = CollectorRegistryBuilder[IO].withJVMMetrics

--- a/modules/solr-client/src/main/scala/io/renku/solr/client/migration/MigrateResult.scala
+++ b/modules/solr-client/src/main/scala/io/renku/solr/client/migration/MigrateResult.scala
@@ -22,9 +22,10 @@ final case class MigrateResult(
     startVersion: Option[Long],
     endVersion: Option[Long],
     migrationsRun: Long,
+    migrationsSkipped: Long,
     reindexRequired: Boolean
 )
 
 object MigrateResult:
   val empty: MigrateResult =
-    MigrateResult(None, None, 0L, false)
+    MigrateResult(None, None, 0L, 0L, false)

--- a/modules/solr-client/src/main/scala/io/renku/solr/client/migration/SchemaMigration.scala
+++ b/modules/solr-client/src/main/scala/io/renku/solr/client/migration/SchemaMigration.scala
@@ -18,7 +18,7 @@
 
 package io.renku.solr.client.migration
 
-import io.renku.solr.client.schema.SchemaCommand
+import io.renku.solr.client.schema.*
 
 final case class SchemaMigration(
     version: Long,
@@ -29,6 +29,31 @@ final case class SchemaMigration(
   def withRequiresReIndex: SchemaMigration =
     copy(requiresReIndex = true)
 
+  def alignWith(schema: CoreSchema): SchemaMigration =
+    copy(commands = commands.filterNot(SchemaMigration.isApplied(schema)))
+
 object SchemaMigration:
   def apply(version: Long, cmd: SchemaCommand, more: SchemaCommand*): SchemaMigration =
     SchemaMigration(version, cmd +: more)
+
+  def isApplied(schema: CoreSchema)(cmd: SchemaCommand): Boolean = cmd match
+    case SchemaCommand.Add(ft: FieldType) =>
+      schema.fieldTypes.exists(_.name == ft.name)
+    case SchemaCommand.Add(f: Field) =>
+      schema.fields.exists(_.name == f.name)
+    case SchemaCommand.Add(r: DynamicFieldRule) =>
+      schema.dynamicFields.exists(_.name == r.name)
+    case SchemaCommand.Add(r: CopyFieldRule) =>
+      schema.copyFields.exists(cf => cf.source == r.source && cf.dest == r.dest)
+    case SchemaCommand.DeleteField(name) =>
+      schema.fields.forall(_.name != name)
+    case SchemaCommand.DeleteType(name) =>
+      schema.fieldTypes.forall(_.name != name)
+    case SchemaCommand.DeleteDynamicField(name) =>
+      schema.dynamicFields.forall(_.name != name)
+    case SchemaCommand.Replace(ft: FieldType) =>
+      schema.fieldTypes.exists(_ == ft)
+    case SchemaCommand.Replace(f: Field) =>
+      schema.fields.exists(_ == f)
+    case SchemaCommand.Replace(r: DynamicFieldRule) =>
+      schema.dynamicFields.exists(_ == r)


### PR DESCRIPTION
The solr schema can be fetched and it is used to test each command in the schema migration if it had already been applied. If not, the command is run and otherwise it is ignored.

With this change it is possible to drop solr entirely, including schema information. On restart, the schema will be fixed by running those changes that haven't been applied.