### PR TITLE
Attach credentials to solr schema requests

### DIFF
--- a/modules/solr-client/src/main/scala/io/renku/solr/client/SolrClientImpl.scala
+++ b/modules/solr-client/src/main/scala/io/renku/solr/client/SolrClientImpl.scala
@@ -122,12 +122,12 @@ private class SolrClientImpl[F[_]: Async](val config: SolrConfig, underlying: Cl
 
   def getSchema: F[SchemaResponse] =
     val url = solrUrl / "schema"
-    val req = Method.GET(url)
+    val req = Method.GET(url).withBasicAuth(credentials)
     underlying.expect[SchemaResponse](req)
 
   def getStatus: F[StatusResponse] =
     val url = config.baseUrl / "api" / "cores"
-    val req = Method.GET(url)
+    val req = Method.GET(url).withBasicAuth(credentials)
     underlying.expect[StatusResponse](req)
 
   def createCore(name: String, configSet: Option[String]): F[Unit] =


### PR DESCRIPTION
This results in migrations not being able to run and thus a not functioning service.