### PR TITLE
Log requests and response at debug level

### DIFF
--- a/modules/http4s-commons/src/main/scala/io/renku/search/http/HttpServer.scala
+++ b/modules/http4s-commons/src/main/scala/io/renku/search/http/HttpServer.scala
@@ -27,6 +27,7 @@ import org.http4s.server.middleware.Logger as Http4sLogger
 import org.http4s.server.Server
 import org.http4s.HttpApp
 import scribe.Scribe
+import org.typelevel.ci.*
 
 final class HttpServer[F[_]: Async](
     builder: EmberServerBuilder[F],
@@ -64,7 +65,8 @@ final class HttpServer[F[_]: Async](
       Http4sLogger.httpApp(
         logHeaders = true,
         logBody = false,
-        logAction = Some(msg => logger.debug(msg))
+        logAction = Some(msg => logger.debug(msg)),
+        redactHeadersWhen = HttpServer.sensitiveHeaders.contains
       )
     )
 
@@ -76,6 +78,9 @@ final class HttpServer[F[_]: Async](
     withHttpApp(routes.orNotFound)
 
 object HttpServer:
+  val sensitiveHeaders: Set[CIString] =
+    Headers.SensitiveHeaders + ci"Renku-Auth-Id-Token"
+
   def default[F[_]: Async: Network]: HttpServer[F] =
     new HttpServer[F](EmberServerBuilder.default[F], Nil)
 

--- a/modules/search-api/src/main/scala/io/renku/search/api/SearchServer.scala
+++ b/modules/search-api/src/main/scala/io/renku/search/api/SearchServer.scala
@@ -69,14 +69,20 @@ object SearchServer:
   private def middleWares[F[_]: Async](
       logger: Scribe[F]
   ): List[HttpRoutes[F] => HttpRoutes[F]] =
-    val log = (str: String) => logger.info(str)
+    val log = (str: String) => logger.debug(str)
     List(
       RequestLogger
-        .httpRoutes(logHeaders = true, logBody = false, logAction = log.some),
+        .httpRoutes(
+          logHeaders = true,
+          logBody = false,
+          logAction = log.some,
+          redactHeadersWhen = HttpServer.sensitiveHeaders.contains
+        ),
       RequestId.httpRoutes[F],
       ResponseLogger.httpRoutes(
         logHeaders = true,
         logBody = false,
-        logAction = log.some
+        logAction = log.some,
+        redactHeadersWhen = HttpServer.sensitiveHeaders.contains
       )
     )


### PR DESCRIPTION
- Requests and responses are now logged at debug level and thus hidden by default

- Add `Renku-Auth-Id-Token` to the list of sensitive headers so they don't appear in logs (the header is not used, but being added to the requests)