### PR TITLE
fix: make namespace mandatory in search results

### DIFF
--- a/modules/commons/src/main/scala/io/renku/logging/LoggingSetup.scala
+++ b/modules/commons/src/main/scala/io/renku/logging/LoggingSetup.scala
@@ -25,9 +25,11 @@ import scribe.writer.SystemOutWriter
 object LoggingSetup:
 
   def doConfigure(verbosity: Int): Unit =
+    val newVerbosity = 5
     println(s">> Setting up logging with verbosity=$verbosity")
+    println(s">> Setting up logging with verbosity=${newVerbosity}")
     val root = scribe.Logger.root.clearHandlers().clearModifiers()
-    verbosity match
+    newVerbosity match
       case n if n < 0 =>
         ()
 

--- a/modules/commons/src/main/scala/io/renku/logging/LoggingSetup.scala
+++ b/modules/commons/src/main/scala/io/renku/logging/LoggingSetup.scala
@@ -25,11 +25,9 @@ import scribe.writer.SystemOutWriter
 object LoggingSetup:
 
   def doConfigure(verbosity: Int): Unit =
-    val newVerbosity = 5
     println(s">> Setting up logging with verbosity=$verbosity")
-    println(s">> Setting up logging with verbosity=${newVerbosity}")
     val root = scribe.Logger.root.clearHandlers().clearModifiers()
-    newVerbosity match
+    verbosity match
       case n if n < 0 =>
         ()
 

--- a/modules/search-api/src/main/scala/io/renku/search/api/data/SearchEntity.scala
+++ b/modules/search-api/src/main/scala/io/renku/search/api/data/SearchEntity.scala
@@ -46,7 +46,7 @@ object SearchEntity:
       id: Id,
       name: Name,
       slug: Slug,
-      namespace: Option[UserOrGroup],
+      namespace: UserOrGroup,
       repositories: Seq[Repository],
       visibility: Visibility,
       description: Option[Description] = None,
@@ -64,7 +64,7 @@ object SearchEntity:
 
   final case class User(
       id: Id,
-      namespace: Option[Namespace] = None,
+      namespace: Namespace,
       firstName: Option[FirstName] = None,
       lastName: Option[LastName] = None,
       score: Option[Double] = None

--- a/modules/search-api/src/main/scala/io/renku/search/api/tapir/ApiSchema.scala
+++ b/modules/search-api/src/main/scala/io/renku/search/api/tapir/ApiSchema.scala
@@ -149,7 +149,7 @@ object ApiSchema:
 
   val exampleUser: SearchEntity.User = User(
     Id("1CAF4C73F50D4514A041C9EDDB025A36"),
-    Some(Namespace("renku/renku")),
+    Namespace("renku/renku"),
     Some(FirstName("Albert")),
     Some(LastName("Einstein")),
     Some(2.1)
@@ -167,7 +167,7 @@ object ApiSchema:
     id = Id("01HRA7AZ2Q234CDQWGA052F8MK"),
     name = Name("renku"),
     slug = Slug("renku"),
-    namespace = Some(exampleGroup),
+    namespace = exampleGroup,
     repositories = Seq(Repository("https://github.com/renku")),
     visibility = Visibility.Public,
     description = Some(Description("Renku project")),


### PR DESCRIPTION
When the namespace field is missing from some results the UI can have unpredictible results.

The API spec for the search was already indicating that these fields can be null and that did not change. 

