### PR TITLE
Restrict search results to valid entities

### DIFF
--- a/modules/search-api/src/test/scala/io/renku/search/api/SearchApiSpec.scala
+++ b/modules/search-api/src/test/scala/io/renku/search/api/SearchApiSpec.scala
@@ -44,7 +44,7 @@ class SearchApiSpec extends CatsEffectSuite with SearchSolrSuite:
     val project1 = projectDocumentGen(
       "matching",
       "matching description",
-      Gen.const(None),
+      userDocumentGen.asOption,
       Gen.const(None),
       Gen.const(Visibility.Public)
     ).generateOne
@@ -76,7 +76,7 @@ class SearchApiSpec extends CatsEffectSuite with SearchSolrSuite:
     val project = projectDocumentGen(
       "exclusive",
       "exclusive description",
-      Gen.const(None),
+      userDocumentGen.asOption,
       Gen.const(None),
       Gen.const(Visibility.Public)
     ).generateOne.copy(createdBy = userId)

--- a/modules/search-solr-client/src/main/scala/io/renku/search/solr/client/RenkuEntityQuery.scala
+++ b/modules/search-solr-client/src/main/scala/io/renku/search/solr/client/RenkuEntityQuery.scala
@@ -41,9 +41,11 @@ object RenkuEntityQuery:
   def apply(role: SearchRole, sq: SolrQuery, limit: Int, offset: Int): QueryData =
     QueryData(QueryString(sq.query.value, limit, offset))
       .addFilter(
-        SolrToken.kindIs(DocumentKind.FullEntity).value,
-        SolrToken.namespaceExists.value,
-        SolrToken.createdByExists.value
+        SolrToken
+          .kindIs(DocumentKind.FullEntity)
+          .value
+//        SolrToken.namespaceExists.value,
+//        SolrToken.createdByExists.value
       )
       .addFilter(constrainRole(role).map(_.value)*)
       .withSort(sq.sort)

--- a/modules/search-solr-client/src/main/scala/io/renku/search/solr/client/RenkuEntityQuery.scala
+++ b/modules/search-solr-client/src/main/scala/io/renku/search/solr/client/RenkuEntityQuery.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.search.solr.client
+
+import io.renku.search.solr.SearchRole
+import io.renku.search.solr.documents.DocumentKind
+import io.renku.search.solr.query.SolrQuery
+import io.renku.search.solr.query.SolrToken
+import io.renku.search.solr.schema.EntityDocumentSchema
+import io.renku.solr.client.*
+import io.renku.solr.client.facet.Facet
+import io.renku.solr.client.facet.Facets
+import io.renku.solr.client.schema.FieldName
+
+/** Convert the user query into a final query that is send to SOLR. */
+object RenkuEntityQuery:
+  private val typeTerms = Facet.Terms(
+    EntityDocumentSchema.Fields.entityType,
+    EntityDocumentSchema.Fields.entityType
+  )
+
+  private val creatorDetails: FieldName = FieldName("creatorDetails")
+  private val namespaceDetails: FieldName = FieldName("namespaceDetails")
+
+  def apply(role: SearchRole, sq: SolrQuery, limit: Int, offset: Int): QueryData =
+    QueryData(QueryString(sq.query.value, limit, offset))
+      .addFilter(
+        SolrToken.kindIs(DocumentKind.FullEntity).value,
+        SolrToken.namespaceExists.value,
+        SolrToken.createdByExists.value
+      )
+      .addFilter(constrainRole(role).map(_.value)*)
+      .withSort(sq.sort)
+      .withFacet(Facets(typeTerms))
+      .withFields(FieldName.all, FieldName.score)
+      .addSubQuery(
+        creatorDetails,
+        SubQuery(
+          "{!terms f=id v=$row.createdBy}",
+          "{!terms f=_kind v=fullentity}",
+          1
+        ).withFields(FieldName.all)
+      )
+      .addSubQuery(
+        namespaceDetails,
+        SubQuery(
+          "{!terms f=namespace v=$row.namespace}",
+          "(_type:User OR _type:Group) AND _kind:fullentity",
+          1
+        ).withFields(FieldName.all)
+      )
+
+  private def constrainRole(role: SearchRole) = role match
+    case SearchRole.Anonymous =>
+      Seq(SolrToken.publicOnly)
+
+    case SearchRole.User(id) =>
+      Seq(SolrToken.forUser(id))
+
+    case SearchRole.Admin(_) =>
+      Seq.empty

--- a/modules/search-solr-client/src/main/scala/io/renku/search/solr/query/LuceneQueryInterpreter.scala
+++ b/modules/search-solr-client/src/main/scala/io/renku/search/solr/query/LuceneQueryInterpreter.scala
@@ -20,7 +20,6 @@ package io.renku.search.solr.query
 
 import cats.Monad
 import cats.effect.Sync
-import cats.syntax.all.*
 
 import io.renku.search.query.Query
 import io.renku.search.solr.SearchRole
@@ -34,15 +33,7 @@ final class LuceneQueryInterpreter[F[_]: Monad]
   private val encoder = SolrTokenEncoder[F, Query]
 
   def run(ctx: Context[F], query: Query): F[SolrQuery] =
-    amendQuery(ctx.role)(encoder.encode(ctx, query))
-
-  private def amendQuery(role: SearchRole)(sq: F[SolrQuery]): F[SolrQuery] =
-    sq.map { query =>
-      role match
-        case SearchRole.Anonymous => query.asAnonymous
-        case SearchRole.User(id)  => query.asUser(id)
-        case SearchRole.Admin(_)  => query.asAdmin
-    }
+    encoder.encode(ctx, query)
 
 object LuceneQueryInterpreter:
   def forSync[F[_]: Sync](role: SearchRole): QueryInterpreter.WithContext[F] =

--- a/modules/search-solr-client/src/main/scala/io/renku/search/solr/query/SolrQuery.scala
+++ b/modules/search-solr-client/src/main/scala/io/renku/search/solr/query/SolrQuery.scala
@@ -36,29 +36,34 @@ final case class SolrQuery(
 
   def asAnonymous: SolrQuery =
     SolrQuery(
-      List(
+      (List(
         query.parens,
-        SolrToken.publicOnly,
-        SolrToken.kindIs(DocumentKind.FullEntity)
-      ).foldAnd,
+        SolrToken.publicOnly
+      ) ::: SolrQuery.mandatoryConstraints).foldAnd,
       sort
     )
 
   def asUser(id: Id): SolrQuery =
     SolrQuery(
-      List(
-        query.parens,
-        SolrToken.forUser(id),
-        SolrToken.kindIs(DocumentKind.FullEntity)
-      ).foldAnd,
+      (List(query.parens, SolrToken.forUser(id))
+        ::: SolrQuery.mandatoryConstraints).foldAnd,
       sort
     )
 
   def asAdmin: SolrQuery =
-    SolrQuery(List(query, SolrToken.kindIs(DocumentKind.FullEntity)).foldAnd, sort)
+    SolrQuery(
+      (query :: SolrQuery.mandatoryConstraints).foldAnd,
+      sort
+    )
 
 object SolrQuery:
   val empty: SolrQuery = SolrQuery(SolrToken.empty, SolrSort.empty)
+
+  private val mandatoryConstraints = List(
+    SolrToken.kindIs(DocumentKind.FullEntity),
+    SolrToken.namespaceExists,
+    SolrToken.createdByExists
+  )
 
   def apply(e: SolrToken): SolrQuery =
     SolrQuery(e, SolrSort.empty)

--- a/modules/search-solr-client/src/main/scala/io/renku/search/solr/query/SolrQuery.scala
+++ b/modules/search-solr-client/src/main/scala/io/renku/search/solr/query/SolrQuery.scala
@@ -21,9 +21,7 @@ package io.renku.search.solr.query
 import cats.Monoid
 import cats.syntax.all.*
 
-import io.renku.search.model.Id
 import io.renku.search.query.Order
-import io.renku.search.solr.documents.DocumentKind
 import io.renku.solr.client.SolrSort
 
 final case class SolrQuery(
@@ -34,36 +32,8 @@ final case class SolrQuery(
   def ++(next: SolrQuery): SolrQuery =
     SolrQuery(query && next.query, sort ++ next.sort)
 
-  def asAnonymous: SolrQuery =
-    SolrQuery(
-      (List(
-        query.parens,
-        SolrToken.publicOnly
-      ) ::: SolrQuery.mandatoryConstraints).foldAnd,
-      sort
-    )
-
-  def asUser(id: Id): SolrQuery =
-    SolrQuery(
-      (List(query.parens, SolrToken.forUser(id))
-        ::: SolrQuery.mandatoryConstraints).foldAnd,
-      sort
-    )
-
-  def asAdmin: SolrQuery =
-    SolrQuery(
-      (query :: SolrQuery.mandatoryConstraints).foldAnd,
-      sort
-    )
-
 object SolrQuery:
   val empty: SolrQuery = SolrQuery(SolrToken.empty, SolrSort.empty)
-
-  private val mandatoryConstraints = List(
-    SolrToken.kindIs(DocumentKind.FullEntity),
-    SolrToken.namespaceExists,
-    SolrToken.createdByExists
-  )
 
   def apply(e: SolrToken): SolrQuery =
     SolrQuery(e, SolrSort.empty)

--- a/modules/search-solr-client/src/main/scala/io/renku/search/solr/query/SolrToken.scala
+++ b/modules/search-solr-client/src/main/scala/io/renku/search/solr/query/SolrToken.scala
@@ -79,6 +79,11 @@ object SolrToken:
   def namespaceIs(ns: Namespace): SolrToken =
     fieldIs(SolrField.namespace, fromNamespace(ns))
 
+  def namespaceExists: SolrToken = fieldExists(SolrField.namespace)
+
+  def createdByExists: SolrToken =
+    "(createdBy:[* TO *] OR (*:* AND -_type:Project))"
+
   def createdDateIs(date: Instant): SolrToken =
     fieldIs(SolrField.creationDate, fromInstant(date))
   def createdDateGt(date: Instant): SolrToken =
@@ -119,7 +124,7 @@ object SolrToken:
     s"${field.name}:$value"
 
   def fieldExists(field: FieldName): SolrToken =
-    fieldIs(field, "*")
+    fieldIs(field, "[* TO *]")
 
   def unsafeFromString(s: String): SolrToken = s
 

--- a/modules/search-solr-client/src/test/scala/io/renku/search/solr/client/RenkuEntityQuerySpec.scala
+++ b/modules/search-solr-client/src/test/scala/io/renku/search/solr/client/RenkuEntityQuerySpec.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2024 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.search.solr.client
+
+import io.renku.search.model.Id
+import io.renku.search.solr.SearchRole
+import io.renku.search.solr.documents.DocumentKind
+import io.renku.search.solr.query.SolrQuery
+import io.renku.search.solr.query.SolrToken
+import io.renku.solr.client.QueryData
+import io.renku.solr.client.SolrSort
+import munit.FunSuite
+
+class RenkuEntityQuerySpec extends FunSuite:
+  val adminRole: SearchRole = SearchRole.admin(Id("admin"))
+
+  def query(q: String, role: SearchRole) =
+    RenkuEntityQuery(
+      role,
+      SolrQuery(SolrToken.unsafeFromString(q), SolrSort.empty),
+      10,
+      0
+    )
+
+  def assertFilter(q: QueryData, fq: String, fqn: String*) =
+    (fq +: fqn).foreach { f =>
+      assert(q.filter.exists(_ == f), s"Expected filter query not found: $f  [$q]")
+    }
+
+  def assertFilterNot(q: QueryData, fq: String, fqn: String*) =
+    (fq +: fqn).foreach { f =>
+      assert(q.filter.forall(_ != f), s"Filter query found: $f")
+    }
+
+  test("amend query with auth data"):
+    assertFilter(
+      query("help", SearchRole.user(Id("13"))),
+      SolrToken.forUser(Id("13")).value
+    )
+    assertFilter(
+      query("help", SearchRole.Anonymous),
+      SolrToken.publicOnly.value
+    )
+    assertFilterNot(
+      query("help", adminRole),
+      SolrToken.publicOnly.value
+    )
+
+  test("only full entities"):
+    assertFilter(
+      query("bla", adminRole),
+      SolrToken.kindIs(DocumentKind.FullEntity).value
+    )
+
+  test("only entities with existing namespace property"):
+    assertFilter(
+      query("bla", adminRole),
+      SolrToken.namespaceExists.value
+    )
+
+  test("only projects with createdBy property"):
+    assertFilter(
+      query("bla", adminRole),
+      SolrToken.createdByExists.value
+    )

--- a/modules/search-solr-client/src/test/scala/io/renku/search/solr/client/SearchSolrClientSpec.scala
+++ b/modules/search-solr-client/src/test/scala/io/renku/search/solr/client/SearchSolrClientSpec.scala
@@ -43,6 +43,29 @@ class SearchSolrClientSpec extends CatsEffectSuite with SearchSolrSuite:
   override def munitFixtures: Seq[munit.AnyFixture[?]] =
     List(solrServer, searchSolrClient)
 
+  test("ignore entities with non-existing namespace"):
+    val user = userDocumentGen.generateOne
+    val group = groupDocumentGen.generateOne
+    val project0 = projectDocumentGen(
+      "project-test0",
+      "project-test0 description",
+      Gen.const(None),
+      Gen.const(None)
+    ).generateOne.copy(createdBy = user.id, namespace = group.namespace.some)
+    val project1 = projectDocumentGen(
+      "project-test1",
+      "project-test1 description",
+      Gen.const(None),
+      Gen.const(None)
+    ).generateOne.copy(createdBy = user.id, namespace = group.namespace.some)
+
+    for
+      client <- IO(searchSolrClient())
+      _ <- IO.println(client)
+      _ <- IO.println(project0)
+      _ <- IO.println(project1)
+    yield ()
+
   test("load project with resolved namespace and creator"):
     val user = userDocumentGen.generateOne
     val group = groupDocumentGen.generateOne

--- a/modules/search-solr-client/src/test/scala/io/renku/search/solr/query/LuceneQueryInterpreterSpec.scala
+++ b/modules/search-solr-client/src/test/scala/io/renku/search/solr/query/LuceneQueryInterpreterSpec.scala
@@ -63,31 +63,6 @@ class LuceneQueryInterpreterSpec extends SearchSolrSuite with ScalaCheckEffectSu
     val q = LuceneQueryInterpreter[Id].run(ctx, userQuery)
     QueryData(QueryString(q.query.value, 10, 0)).withSort(q.sort)
 
-  test("amend query with auth data"):
-    assertEquals(
-      query("help", SearchRole.user(model.Id("13"))).query,
-      "((content_all:help~) AND (visibility:public OR members_all:13) AND _kind:fullentity)"
-    )
-    assertEquals(
-      query("help", SearchRole.Anonymous).query,
-      "((content_all:help~) AND visibility:public AND _kind:fullentity)"
-    )
-    assertEquals(
-      query("help", adminRole).query,
-      "(content_all:help~ AND _kind:fullentity)"
-    )
-
-  test("amend empty query with auth data"):
-    assertEquals(
-      query("", SearchRole.user(model.Id("13"))).query,
-      "((visibility:public OR members_all:13) AND _kind:fullentity)"
-    )
-    assertEquals(
-      query("", SearchRole.Anonymous).query,
-      "(visibility:public AND _kind:fullentity)"
-    )
-    assertEquals(query("", adminRole).query, "(_kind:fullentity)")
-
   test("valid content_all query") {
     IO(solrClientWithSchema()).flatMap { client =>
       List("hello world", "bla:test")

--- a/modules/solr-client/src/main/scala/io/renku/solr/client/QueryData.scala
+++ b/modules/solr-client/src/main/scala/io/renku/solr/client/QueryData.scala
@@ -20,9 +20,9 @@ package io.renku.solr.client
 
 import io.bullet.borer.Encoder
 import io.bullet.borer.derivation.MapBasedCodecs.deriveEncoder
+import io.renku.solr.client.SolrSort.Direction
 import io.renku.solr.client.facet.Facets
 import io.renku.solr.client.schema.FieldName
-import io.renku.solr.client.SolrSort.Direction
 
 final case class QueryData(
     query: String,
@@ -41,7 +41,8 @@ final case class QueryData(
   def appendSort(field: FieldName, dir: Direction = Direction.Asc): QueryData =
     copy(sort = sort + (field -> dir))
   def withFields(field: FieldName*) = copy(fields = field)
-  def addFilter(q: String): QueryData = copy(filter = filter :+ q)
+  def withFilter(fq: Seq[String]): QueryData = copy(filter = fq)
+  def addFilter(q: String*): QueryData = copy(filter = filter ++ q)
   def withFacet(facet: Facets): QueryData = copy(facet = facet)
   def withLimit(limit: Int): QueryData = copy(limit = limit)
   def withOffset(offset: Int): QueryData = copy(offset = offset)

--- a/modules/solr-client/src/main/scala/io/renku/solr/client/QueryData.scala
+++ b/modules/solr-client/src/main/scala/io/renku/solr/client/QueryData.scala
@@ -22,6 +22,7 @@ import io.bullet.borer.Encoder
 import io.bullet.borer.derivation.MapBasedCodecs.deriveEncoder
 import io.renku.solr.client.facet.Facets
 import io.renku.solr.client.schema.FieldName
+import io.renku.solr.client.SolrSort.Direction
 
 final case class QueryData(
     query: String,
@@ -37,11 +38,24 @@ final case class QueryData(
     copy(offset = offset + limit)
 
   def withSort(sort: SolrSort): QueryData = copy(sort = sort)
+  def appendSort(field: FieldName, dir: Direction = Direction.Asc): QueryData =
+    copy(sort = sort + (field -> dir))
   def withFields(field: FieldName*) = copy(fields = field)
   def addFilter(q: String): QueryData = copy(filter = filter :+ q)
   def withFacet(facet: Facets): QueryData = copy(facet = facet)
   def withLimit(limit: Int): QueryData = copy(limit = limit)
   def withOffset(offset: Int): QueryData = copy(offset = offset)
+  def withCursor(cursorMark: CursorMark): QueryData =
+    copy(params = params.updated("cursorMark", cursorMark.render))
+
+  /** When using a cursor, it is required to add a `uniqueKey`field to the sort clause to
+    * guarantee a deterministic order.
+    */
+  def withCursor(cursorMark: CursorMark, keyField: FieldName): QueryData =
+    copy(
+      params = params.updated("cursorMark", cursorMark.render),
+      sort = sort + (keyField -> SolrSort.Direction.Asc)
+    )
 
   def addSubQuery(field: FieldName, sq: SubQuery): QueryData =
     copy(

--- a/modules/solr-client/src/main/scala/io/renku/solr/client/SolrClientImpl.scala
+++ b/modules/solr-client/src/main/scala/io/renku/solr/client/SolrClientImpl.scala
@@ -24,6 +24,7 @@ import cats.data.NonEmptyList
 import cats.effect.Async
 import cats.syntax.all.*
 
+import io.bullet.borer.Json
 import io.bullet.borer.{Decoder, Encoder}
 import io.renku.search.http.borer.BorerEntityJsonCodec
 import io.renku.search.http.{HttpClientDsl, ResponseLogging}
@@ -31,7 +32,6 @@ import io.renku.solr.client.schema.{SchemaCommand, SchemaJsonCodec}
 import org.http4s.Status
 import org.http4s.client.Client
 import org.http4s.{BasicCredentials, Method, Uri}
-import io.bullet.borer.Json
 
 private class SolrClientImpl[F[_]: Async](val config: SolrConfig, underlying: Client[F])
     extends SolrClient[F]

--- a/modules/solr-client/src/main/scala/io/renku/solr/client/SolrClientImpl.scala
+++ b/modules/solr-client/src/main/scala/io/renku/solr/client/SolrClientImpl.scala
@@ -31,6 +31,7 @@ import io.renku.solr.client.schema.{SchemaCommand, SchemaJsonCodec}
 import org.http4s.Status
 import org.http4s.client.Client
 import org.http4s.{BasicCredentials, Method, Uri}
+import io.bullet.borer.Json
 
 private class SolrClientImpl[F[_]: Async](val config: SolrConfig, underlying: Client[F])
     extends SolrClient[F]
@@ -52,9 +53,10 @@ private class SolrClientImpl[F[_]: Async](val config: SolrConfig, underlying: Cl
 
   def query[A: Decoder](query: QueryData): F[QueryResponse[A]] =
     val req = Method.POST(query, solrUrl / "query").withBasicAuth(credentials)
-    underlying
-      .expectOr[QueryResponse[A]](req)(ResponseLogging.Error(logger, req))
-      .flatTap(r => logger.trace(s"Query response: $r"))
+    logger.debug(s"SOLR Query: ${Json.encode(query).toUtf8String}") >>
+      underlying
+        .expectOr[QueryResponse[A]](req)(ResponseLogging.Error(logger, req))
+        .flatTap(r => logger.trace(s"Query response: $r"))
 
   def delete(q: QueryString): F[Unit] =
     val req = Method.POST(DeleteRequest(q.q), makeUpdateUrl).withBasicAuth(credentials)

--- a/modules/solr-client/src/main/scala/io/renku/solr/client/SolrSort.scala
+++ b/modules/solr-client/src/main/scala/io/renku/solr/client/SolrSort.scala
@@ -50,6 +50,10 @@ object SolrSort:
     def nonEmpty: Boolean = !self.isEmpty
     def ++(next: SolrSort): SolrSort =
       Monoid[SolrSort].combine(self, next)
+
+    def +(n: (FieldName, Direction)): SolrSort =
+      self ++ Seq(n)
+
     private[client] def toSolr: String =
       self.map { case (f, d) => s"${f.name} ${d.name}" }.mkString(",")
 

--- a/modules/solr-client/src/main/scala/io/renku/solr/client/schema/FieldName.scala
+++ b/modules/solr-client/src/main/scala/io/renku/solr/client/schema/FieldName.scala
@@ -25,6 +25,7 @@ opaque type FieldName = String
 object FieldName:
   val all: FieldName = "*"
   val score: FieldName = "score"
+  val id: FieldName = "id"
 
   def apply(name: String): FieldName = name
 


### PR DESCRIPTION
This removes results from search as has been discussed:

- projects that don't have a `createdBy` property (this should always be there, such a property missing indicates a processing error)
- entities whose `namespace` can not be found, resolving it yields no results
