### PR TITLE
Add pagination with cursor to solr client

### DIFF
--- a/modules/solr-client/src/main/scala/io/renku/solr/client/QueryData.scala
+++ b/modules/solr-client/src/main/scala/io/renku/solr/client/QueryData.scala
@@ -20,6 +20,7 @@ package io.renku.solr.client
 
 import io.bullet.borer.Encoder
 import io.bullet.borer.derivation.MapBasedCodecs.deriveEncoder
+import io.renku.solr.client.SolrSort.Direction
 import io.renku.solr.client.facet.Facets
 import io.renku.solr.client.schema.FieldName
 
@@ -37,11 +38,24 @@ final case class QueryData(
     copy(offset = offset + limit)
 
   def withSort(sort: SolrSort): QueryData = copy(sort = sort)
+  def appendSort(field: FieldName, dir: Direction = Direction.Asc): QueryData =
+    copy(sort = sort + (field -> dir))
   def withFields(field: FieldName*) = copy(fields = field)
   def addFilter(q: String): QueryData = copy(filter = filter :+ q)
   def withFacet(facet: Facets): QueryData = copy(facet = facet)
   def withLimit(limit: Int): QueryData = copy(limit = limit)
   def withOffset(offset: Int): QueryData = copy(offset = offset)
+  def withCursor(cursorMark: CursorMark): QueryData =
+    copy(params = params.updated("cursorMark", cursorMark.render))
+
+  /** When using a cursor, it is required to add a `uniqueKey`field to the sort clause to
+    * guarantee a deterministic order.
+    */
+  def withCursor(cursorMark: CursorMark, keyField: FieldName): QueryData =
+    copy(
+      params = params.updated("cursorMark", cursorMark.render),
+      sort = sort + (keyField -> SolrSort.Direction.Asc)
+    )
 
   def addSubQuery(field: FieldName, sq: SubQuery): QueryData =
     copy(

--- a/modules/solr-client/src/main/scala/io/renku/solr/client/SolrSort.scala
+++ b/modules/solr-client/src/main/scala/io/renku/solr/client/SolrSort.scala
@@ -50,6 +50,10 @@ object SolrSort:
     def nonEmpty: Boolean = !self.isEmpty
     def ++(next: SolrSort): SolrSort =
       Monoid[SolrSort].combine(self, next)
+
+    def +(n: (FieldName, Direction)): SolrSort =
+      self ++ Seq(n)
+
     private[client] def toSolr: String =
       self.map { case (f, d) => s"${f.name} ${d.name}" }.mkString(",")
 

--- a/modules/solr-client/src/main/scala/io/renku/solr/client/schema/FieldName.scala
+++ b/modules/solr-client/src/main/scala/io/renku/solr/client/schema/FieldName.scala
@@ -25,6 +25,7 @@ opaque type FieldName = String
 object FieldName:
   val all: FieldName = "*"
   val score: FieldName = "score"
+  val id: FieldName = "id"
 
   def apply(name: String): FieldName = name
 


### PR DESCRIPTION
This adds the ability to use a cursor for paginated results to the solr client library.