### PR TITLE
Auto-approve dependency updates from RenkuBot

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,17 @@
+name: Auto approve
+
+on:
+  pull_request_target
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hmarr/auto-approve-action@v4
+        if: github.actor == 'RenkuBot'
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The PRs for dependency updates should get merged automatically. Now it requires a approval for merging which this workflow should do.